### PR TITLE
Allow heteron on neumes containing kentimata and petasti

### DIFF
--- a/docs/orthographic_rules.md
+++ b/docs/orthographic_rules.md
@@ -7,7 +7,7 @@
 ## Kentemata
 
 - Kentemata may never hold more than one beat, and thus cannot take a klasma, hapli, etc. If a kentemata needs to be held for more than one beat, an ison must placed after it and given the appropriate duration. This also applies to compound neumes that end in kentemata.
-- Kentemata may never take vocal expression neumes.
+- Kentemata may never take vocal expression neumes (except for the heteron).
 
 ## Gorgon
 

--- a/src/models/NeumeReplacements.ts
+++ b/src/models/NeumeReplacements.ts
@@ -349,15 +349,6 @@ export const vocalExpressionReplacementMap = new Map<
     ],
   ],
   [
-    VocalExpressionNeume.Heteron,
-    [
-      {
-        isPairedWith: [...petastiNeumes],
-        replaceWith: null,
-      },
-    ],
-  ],
-  [
     VocalExpressionNeume.Homalon,
     [
       {

--- a/src/models/NeumeReplacements.ts
+++ b/src/models/NeumeReplacements.ts
@@ -352,7 +352,7 @@ export const vocalExpressionReplacementMap = new Map<
     VocalExpressionNeume.Heteron,
     [
       {
-        isPairedWith: [...petastiNeumes, ...kentemataNeumes],
+        isPairedWith: [...petastiNeumes],
         replaceWith: null,
       },
     ],


### PR DESCRIPTION
Resolves #5

For the kentimata:
The app was following (too literally) the rule found in Byzantine Ecclesiastical Music by Basilios Psilacos, page 112: 

```
[The kentimata] does not accept chronic characters for increasing its time, nor
the expression characters.
```

However, this rule does not actually apply to the heteron, which can be confirmed by looking through, for example, the Anastasimatarion of John the Protopsaltist (cf. pg 296). 

For the petasti: 
This was a mistake. It is clearly possible for the petasti to accept the heteron. See page 294 of the Anastasimatarion of John the Protopsaltist