### PR TITLE
`git status` is not clean after build

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -31,6 +31,7 @@ jobs:
           path: ./node_modules
           key: ${{ runner.os }}-modules-${{ hashFiles('package-lock.json') }}
 
+      - run: corepack enable npm
       - name: Install dependencies
         if: steps.cache.outputs.cache-hit != 'true'
         run: npm ci

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -25,6 +25,7 @@ jobs:
           path: ./node_modules
           key: ${{ runner.os }}-modules-${{ hashFiles('package-lock.json') }}
 
+      - run: corepack enable npm
       - name: Install dependencies
         if: steps.cache.outputs.cache-hit != 'true'
         run: npm ci

--- a/.github/workflows/publish-web.yml
+++ b/.github/workflows/publish-web.yml
@@ -24,6 +24,7 @@ jobs:
           path: ./node_modules
           key: ${{ runner.os }}-modules-${{ hashFiles('package-lock.json') }}
 
+      - run: corepack enable npm
       - name: Install dependencies
         if: steps.cache.outputs.cache-hit != 'true'
         run: npm ci

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -27,6 +27,7 @@ jobs:
           path: ./node_modules
           key: ${{ runner.os }}-modules-${{ hashFiles('package-lock.json') }}
 
+      - run: corepack enable npm
       - name: Install dependencies
         if: steps.cache.outputs.cache-hit != 'true'
         run: npm ci

--- a/README.md
+++ b/README.md
@@ -43,13 +43,14 @@ To learn how to use the software, read the [guide](https://danielgarthur.github.
 
 ### Prerequisites
 
-- Node.js 16
+- Node.js 16.9.0 or later
 
 ### Project Setup
 
 First install the project dependencies:
 
 ```
+corepack enable npm
 npm install
 ```
 

--- a/README.md
+++ b/README.md
@@ -73,6 +73,8 @@ npm run electron:serve
 
 This will launch the application in development mode. As changes are made to the source code, the app will reload automatically.
 
+Any change that updates `package.json` _must_ include the corresponding update to `package-lock.json` after running `npm install`.
+
 ### Code Formatting
 
 To format the code before committing, type:

--- a/package.json
+++ b/package.json
@@ -82,5 +82,6 @@
       "electron-builder": "^23.6.0"
     }
   },
-  "license": "GPL-3.0"
+  "license": "GPL-3.0",
+  "packageManager": "npm@8.1.2"
 }


### PR DESCRIPTION
### Environment

Ubuntu 22.04.2 LTS x86_64
Node v16.20.0
NPM 8.19.4

### Steps to reproduce

```bash
$ git checkout 26059a0  # HEAD
$ git clean -fxd
$ npm install
$ git status
```

### Expected results

`git status` is clean.

### Actual results

`git status` shows:

```
$ git status
[…]
modified:   package-lock.json
[…]
```

### Evaluation

`package-lock.json` was not checked in after a recent modification to `package.json`.

### Solution

Run `git add package-lock.json`.

### Testing done

```bash
$ git clean -fxd
$ git status  # clean
$ npm install
$ git status  # clean
$ npm test
$ npm run electron:build
$ ./dist_electron/Neanes-0.3.0-beta.19.AppImage  # success
```

Fixes #99.