### PR TITLE
Add comment to empty catch block

### DIFF
--- a/src/background.ts
+++ b/src/background.ts
@@ -165,7 +165,9 @@ async function showReplaceFileDialog(filePath: string) {
     });
 
     return replaceFileResult.response === 1;
-  } catch {}
+  } catch {
+    // ignore
+  }
 
   return true;
 }
@@ -186,7 +188,9 @@ async function showReplaceOrSkipFileDialog(filePath: string) {
     });
 
     return replaceFileResult.response as OnConflictChoice;
-  } catch {}
+  } catch {
+    // ignore
+  }
 
   return OnConflictChoice.Replace;
 }


### PR DESCRIPTION
Newer versions of ESLint report:

```
error: Empty block statement (no-empty) at src/background.ts:168:11:
  166 |
  167 |     return replaceFileResult.response === 1;
> 168 |   } catch {}
      |           ^
  169 |
  170 |   return true;
  171 | }


error: Empty block statement (no-empty) at src/background.ts:189:11:
  187 |
  188 |     return replaceFileResult.response as OnConflictChoice;
> 189 |   } catch {}
      |           ^
  190 |
  191 |   return OnConflictChoice.Replace;
  192 | }
```

This PR is compatible with the current version of ESLint but unblocks a future upgrade. Regression tested with:

```bash
$ npm ci
$ npm test
$ npm run electron:build
```

Also verified that in my local branch that updates a number of dependencies, the abovementioned error in newer versions of ESLint went away.