### PR TITLE
Constify TypeScript files

### DIFF
--- a/src/background.ts
+++ b/src/background.ts
@@ -87,7 +87,7 @@ const defaultStore = {
   windowState: defaultWindowState,
 };
 
-let store: Store = defaultStore;
+const store: Store = defaultStore;
 
 interface SecondInstanceData {
   argv: string[];
@@ -276,7 +276,7 @@ async function openFileFromArgs(argv: string[]) {
   // parameters is now an array containing any files/folders that your OS will pass to your application
   const parameters = argv.slice(2);
 
-  for (let parameter of parameters) {
+  for (const parameter of parameters) {
     try {
       result.push({
         data: await openFile(parameters[0]),
@@ -576,7 +576,7 @@ async function exportWorkspaceAsHtml(args: ExportWorkspaceAsHtmlArgs) {
 }
 
 async function exportWorkspaceAsImage(args: ExportWorkspaceAsImageArgs) {
-  let result = {
+  const result = {
     filePath: args.filePath,
     success: false,
   } as ExportWorkspaceAsImageReplyArgs;
@@ -797,7 +797,7 @@ function ensureVisibleOnSomeDisplay(windowState: WindowState) {
 }
 
 function createMenu() {
-  var menu = Menu.buildFromTemplate([
+  const menu = Menu.buildFromTemplate([
     ...(isMac
       ? ([
           {

--- a/src/ipc/ipcListeners.ts
+++ b/src/ipc/ipcListeners.ts
@@ -7,13 +7,13 @@ import { IpcMainChannels, IpcRendererChannels } from './ipcChannels';
  * implemented that uses the Event Bus to send the same events.
  */
 export const initializeIpcListeners = () => {
-  for (let channel of Object.values(IpcMainChannels)) {
+  for (const channel of Object.values(IpcMainChannels)) {
     window.ipcRenderer.on(channel, (...args) => {
       EventBus.$emit(channel, ...args);
     });
   }
 
-  for (let channel of Object.values(IpcRendererChannels)) {
+  for (const channel of Object.values(IpcRendererChannels)) {
     EventBus.$on(channel, (...args: any[]) => {
       window.ipcRenderer.send(channel, ...args);
     });

--- a/src/models/Scales.ts
+++ b/src/models/Scales.ts
@@ -93,13 +93,13 @@ const isonToNoteValueMap = new Map<Ison, number>([
 
 const noteValueToScaleNoteMap = new Map<number, ScaleNote>();
 
-for (let [key, value] of scaleNoteToNoteValueMap) {
+for (const [key, value] of scaleNoteToNoteValueMap) {
   noteValueToScaleNoteMap.set(value, key);
 }
 
 const noteValueToNoteMap = new Map<number, Note>();
 
-for (let [key, value] of noteToNoteValueMap) {
+for (const [key, value] of noteToNoteValueMap) {
   noteValueToNoteMap.set(value, key);
 }
 

--- a/src/services/LayoutService.ts
+++ b/src/services/LayoutService.ts
@@ -428,7 +428,7 @@ export class LayoutService {
         // Calculate the current page height
         currentPageHeightPx = 0;
 
-        for (let line of page.lines) {
+        for (const line of page.lines) {
           let height = 0;
 
           if (
@@ -961,8 +961,8 @@ export class LayoutService {
   }
 
   public static justifyLines(pages: Page[], pageSetup: PageSetup) {
-    for (let page of pages) {
-      for (let line of page.lines) {
+    for (const page of pages) {
+      for (const line of page.lines) {
         if (
           pages.indexOf(page) === pages.length - 1 &&
           page.lines.indexOf(line) === page.lines.length - 1
@@ -997,23 +997,23 @@ export class LayoutService {
           continue;
         }
 
-        let alignCenter = line.elements.some(
+        const alignCenter = line.elements.some(
           (x) =>
             x.lineBreak == true && x.lineBreakType === LineBreakType.Center,
         );
 
-        let currentWidthPx = line.elements
+        const currentWidthPx = line.elements
           .map((x) => x.width)
           .reduce((sum, x) => sum + x, 0);
 
-        let extraSpace = pageSetup.innerPageWidth - currentWidthPx;
+        const extraSpace = pageSetup.innerPageWidth - currentWidthPx;
 
         if (alignCenter) {
           for (let i = 0; i < line.elements.length; i++) {
             line.elements[i].x += extraSpace / 2;
           }
         } else {
-          let spaceToAdd = extraSpace / (line.elements.length - 1);
+          const spaceToAdd = extraSpace / (line.elements.length - 1);
 
           for (let i = 1; i < line.elements.length; i++) {
             line.elements[i].x += spaceToAdd * i;
@@ -1056,13 +1056,13 @@ export class LayoutService {
       `${pageSetup.neumeDefaultFontSize}px ${pageSetup.neumeDefaultFontFamily}`,
     );
 
-    for (let page of pages) {
-      for (let line of page.lines) {
+    for (const page of pages) {
+      for (const line of page.lines) {
         const noteElements = line.elements.filter(
           (x) => x.elementType === ElementType.Note,
         ) as NoteElement[];
 
-        for (let element of noteElements) {
+        for (const element of noteElements) {
           const index = line.elements.indexOf(element);
 
           const isIntermediateMelismaAtStartOfLine =
@@ -1255,7 +1255,7 @@ export class LayoutService {
     let ambitusHighShift = 0;
     let currentModeKey: ModeKeyElement | null = null;
 
-    for (let element of elements) {
+    for (const element of elements) {
       if (element.elementType === ElementType.Note) {
         const note = element as NoteElement;
         currentNote += getNeumeValue(note.quantitativeNeume)!;
@@ -1263,9 +1263,9 @@ export class LayoutService {
           ((currentNote % 7) + 7) % 7,
         )!;
 
-        let noteSpread = getNoteSpread(note.quantitativeNeume);
+        const noteSpread = getNoteSpread(note.quantitativeNeume);
 
-        let currentNotes = noteSpread.map((x) => currentNote + x);
+        const currentNotes = noteSpread.map((x) => currentNote + x);
 
         note.scaleNotes = noteSpread.map((x) =>
           getScaleNoteFromValue(currentNote + x),
@@ -1317,7 +1317,7 @@ export class LayoutService {
           }
         }
 
-        for (let noteValue of currentNotes) {
+        for (const noteValue of currentNotes) {
           if (noteValue < ambitusLow) {
             ambitusLow = noteValue;
             ambitusLowScale = currentScale;
@@ -1736,7 +1736,7 @@ const noteIndicatorMap = new Map<number, NoteIndicator>([
 
 const reverseNoteMap = new Map<Note, number>();
 
-for (let [key, value] of noteMap) {
+for (const [key, value] of noteMap) {
   reverseNoteMap.set(value, key);
 }
 
@@ -1824,6 +1824,6 @@ const lowRootSignMap = new Map<RootSign, RootSign>([
 
 const highRootSignMap = new Map<RootSign, RootSign>();
 
-for (let [key, value] of lowRootSignMap) {
+for (const [key, value] of lowRootSignMap) {
   highRootSignMap.set(value, key);
 }

--- a/src/services/NeumeKeyboard.ts
+++ b/src/services/NeumeKeyboard.ts
@@ -1582,7 +1582,7 @@ export class NeumeKeyboard {
     result.push('| Neume | Keyboard Shortcut |\n');
     result.push('| ----- | ----------------- |\n');
 
-    for (let mapping of mappings) {
+    for (const mapping of mappings) {
       result.push('|');
 
       result.push(

--- a/src/services/NeumeMappingService.ts
+++ b/src/services/NeumeMappingService.ts
@@ -33,13 +33,13 @@ export interface NeumeMapping {
 // Create mapping from glyph name to codepoint
 const glyphNameToCodepointMap = new Map<string, string>();
 
-for (let glyph in glyphnames) {
+for (const glyph in glyphnames) {
   const data: { codepoint: string } = (glyphnames as any)[glyph];
   const codepoint = Number('0x' + data.codepoint.substring(2));
   glyphNameToCodepointMap.set(glyph, String.fromCodePoint(codepoint));
 }
 
-for (let glyph in metadata.optionalGlyphs) {
+for (const glyph in metadata.optionalGlyphs) {
   const data: { codepoint: string } = (metadata.optionalGlyphs as any)[glyph];
   const codepoint = Number('0x' + data.codepoint.substring(2));
   glyphNameToCodepointMap.set(glyph, String.fromCodePoint(codepoint));

--- a/src/services/SaveService.ts
+++ b/src/services/SaveService.ts
@@ -78,7 +78,7 @@ export class SaveService {
     this.SaveFooter(score.footers.odd, s.footers.odd);
     this.SaveFooter(score.footers.firstPage, s.footers.firstPage);
 
-    for (let e of s.staff.elements) {
+    for (const e of s.staff.elements) {
       let element: ScoreElement_v1 = new EmptyElement_v1();
 
       switch (e.elementType) {
@@ -483,7 +483,7 @@ export class SaveService {
       this.LoadFooter_v1(score.footers.firstPage, s.footers.firstPage);
     }
 
-    for (let e of s.staff.elements) {
+    for (const e of s.staff.elements) {
       let element: ScoreElement = new EmptyElement();
 
       switch (e.elementType) {

--- a/src/services/TextMeasurementService.ts
+++ b/src/services/TextMeasurementService.ts
@@ -2,34 +2,34 @@ export class TextMeasurementService {
   private static canvas: HTMLCanvasElement | null = null;
 
   public static getTextWidth(text: string, font: string) {
-    let canvas = this.canvas || document.createElement('canvas');
-    let context = canvas.getContext('2d')!;
+    const canvas = this.canvas || document.createElement('canvas');
+    const context = canvas.getContext('2d')!;
     context.font = font;
-    let metrics = context.measureText(text);
+    const metrics = context.measureText(text);
     return metrics.width;
   }
 
   public static getTextHeight(text: string, font: string) {
-    let canvas = this.canvas || document.createElement('canvas');
-    let context = canvas.getContext('2d')!;
+    const canvas = this.canvas || document.createElement('canvas');
+    const context = canvas.getContext('2d')!;
     context.font = font;
-    let metrics = context.measureText(text);
+    const metrics = context.measureText(text);
     return metrics.actualBoundingBoxAscent + metrics.actualBoundingBoxDescent;
   }
 
   public static getFontHeight(font: string) {
-    let canvas = this.canvas || document.createElement('canvas');
-    let context = canvas.getContext('2d')!;
+    const canvas = this.canvas || document.createElement('canvas');
+    const context = canvas.getContext('2d')!;
     context.font = font;
-    let metrics = context.measureText('');
+    const metrics = context.measureText('');
     return metrics.fontBoundingBoxAscent + metrics.fontBoundingBoxDescent;
   }
 
   public static getFontBoundingBoxDescent(text: string, font: string) {
-    let canvas = this.canvas || document.createElement('canvas');
-    let context = canvas.getContext('2d')!;
+    const canvas = this.canvas || document.createElement('canvas');
+    const context = canvas.getContext('2d')!;
     context.font = font;
-    let metrics = context.measureText(text);
+    const metrics = context.measureText(text);
     return metrics.fontBoundingBoxDescent;
   }
 }

--- a/src/services/audio/AudioService.ts
+++ b/src/services/audio/AudioService.ts
@@ -76,7 +76,7 @@ export class AudioService {
 
     Tone.Transport.bpm.value = startAt?.bpm ?? 60;
 
-    for (let event of events) {
+    for (const event of events) {
       if (currentBpm !== event.bpm) {
         Tone.Transport.bpm.value = event.bpm!;
       }
@@ -293,7 +293,7 @@ export class AudioService {
   playTestTone(frequency: number) {
     this.synth.volume.value = 0;
     Tone.Transport.bpm.value = 120;
-    let now = Tone.now();
+    const now = Tone.now();
 
     this.synth.triggerAttackRelease(frequency, '2n', now);
   }
@@ -305,7 +305,7 @@ export class AudioService {
     let currentFrequency = 261.63;
     let now = Tone.now();
 
-    for (let interval of scale) {
+    for (const interval of scale) {
       synth.triggerAttackRelease(currentFrequency, '8n', now);
       currentFrequency = this.nextNote(currentFrequency, interval);
       now += 0.5;

--- a/src/services/audio/PlaybackService.test.ts
+++ b/src/services/audio/PlaybackService.test.ts
@@ -732,7 +732,7 @@ function getDefaultWorkspaceOptions() {
 }
 
 function getDefaultWorkspace(elements: ScoreElement[], scale: PlaybackScale) {
-  let workspace: PlaybackWorkspace = {
+  const workspace: PlaybackWorkspace = {
     events: [],
     gorgonIndexes: [],
 

--- a/src/services/audio/PlaybackService.ts
+++ b/src/services/audio/PlaybackService.ts
@@ -139,7 +139,7 @@ export interface PlaybackScale {
 
 export class PlaybackService {
   constructor() {
-    for (let [key, value] of this.scaleNoteMap) {
+    for (const [key, value] of this.scaleNoteMap) {
       this.reverseScaleNoteMap.set(value, key);
     }
   }
@@ -149,7 +149,7 @@ export class PlaybackService {
 
     const defaultBpm = 120;
 
-    let workspace: PlaybackWorkspace = {
+    const workspace: PlaybackWorkspace = {
       events: [],
       gorgonIndexes: [],
       elements,
@@ -227,7 +227,7 @@ export class PlaybackService {
     workspace.isonFrequency = 0;
 
     for (let i = 0; i < elements.length; i++) {
-      let element = elements[i];
+      const element = elements[i];
 
       workspace.elementIndex = i;
       workspace.currentNoteElement = null;
@@ -244,9 +244,9 @@ export class PlaybackService {
 
           const destinationNote = workspace.note + distance;
 
-          let noteSpread = getNoteSpread(noteElement.quantitativeNeume);
+          const noteSpread = getNoteSpread(noteElement.quantitativeNeume);
 
-          let allNotes = noteSpread.map((x) =>
+          const allNotes = noteSpread.map((x) =>
             this.scaleNoteMap.get(destinationNote + x),
           );
 
@@ -403,7 +403,7 @@ export class PlaybackService {
     let currentBpm = defaultBpm;
     let currentBeatLength = this.beatLengthFromBpm(currentBpm);
 
-    for (let event of workspace.events) {
+    for (const event of workspace.events) {
       if (currentBpm != event.bpm) {
         currentBpm = event.bpm;
         currentBeatLength = this.beatLengthFromBpm(currentBpm);
@@ -443,7 +443,7 @@ export class PlaybackService {
     const sign = Math.sign(distance);
 
     for (let i = 0; i < abs; i++) {
-      let index =
+      const index =
         sign > 0
           ? intervalIndex
           : this.mod(intervalIndex - 1, intervals.length);
@@ -929,7 +929,7 @@ export class PlaybackService {
       gorgonIndexes.push(gorgonIndex);
     }
 
-    let alteredFrequency = this.applyAlterations(workspace);
+    const alteredFrequency = this.applyAlterations(workspace);
 
     const event: PlaybackSequenceEvent = {
       frequency: alteredFrequency,
@@ -958,7 +958,7 @@ export class PlaybackService {
     }
 
     // Calculate accidentals
-    let alteredFrequencyKentimata = this.applyAlterations(
+    const alteredFrequencyKentimata = this.applyAlterations(
       workspace,
       noteElement.accidental,
     );
@@ -999,7 +999,7 @@ export class PlaybackService {
       gorgonIndexes.push(gorgonIndex);
     }
 
-    let alteredFrequencyKentimata = this.applyAlterations(workspace);
+    const alteredFrequencyKentimata = this.applyAlterations(workspace);
 
     const kentimataEvent: PlaybackSequenceEvent = {
       frequency: alteredFrequencyKentimata,
@@ -1026,7 +1026,7 @@ export class PlaybackService {
     }
 
     // Calculate accidentals
-    let alteredFrequency = this.applyAlterations(
+    const alteredFrequency = this.applyAlterations(
       workspace,
       noteElement.accidental,
     );
@@ -1064,7 +1064,7 @@ export class PlaybackService {
       gorgonIndexes.push(gorgonIndex);
     }
 
-    let alteredFrequency1 = this.applyAlterations(workspace);
+    const alteredFrequency1 = this.applyAlterations(workspace);
 
     const event1: PlaybackSequenceEvent = {
       frequency: alteredFrequency1,
@@ -1091,7 +1091,7 @@ export class PlaybackService {
     }
 
     // Calculate accidentals
-    let alteredFrequency2 = this.applyAlterations(
+    const alteredFrequency2 = this.applyAlterations(
       workspace,
       noteElement.accidental,
     );
@@ -1132,7 +1132,7 @@ export class PlaybackService {
       gorgonIndexes.push(gorgonIndex);
     }
 
-    let alteredFrequency1 = this.applyAlterations(workspace);
+    const alteredFrequency1 = this.applyAlterations(workspace);
 
     const event1: PlaybackSequenceEvent = {
       frequency: alteredFrequency1,
@@ -1159,7 +1159,7 @@ export class PlaybackService {
     }
 
     // Calculate accidentals
-    let alteredFrequency2 = this.applyAlterations(workspace);
+    const alteredFrequency2 = this.applyAlterations(workspace);
 
     const event2: PlaybackSequenceEvent = {
       frequency: alteredFrequency2,
@@ -1188,7 +1188,7 @@ export class PlaybackService {
     }
 
     // Calculate accidentals
-    let alteredFrequencyKentimata = this.applyAlterations(
+    const alteredFrequencyKentimata = this.applyAlterations(
       workspace,
       noteElement.accidental,
     );
@@ -1229,7 +1229,7 @@ export class PlaybackService {
       gorgonIndexes.push(gorgonIndex);
     }
 
-    let alteredFrequency1 = this.applyAlterations(workspace);
+    const alteredFrequency1 = this.applyAlterations(workspace);
 
     const event1: PlaybackSequenceEvent = {
       frequency: alteredFrequency1,
@@ -1246,7 +1246,7 @@ export class PlaybackService {
     // Process the second apsotrofos
     workspace.innerElementIndex = 1;
 
-    let event2Duration = 1 * workspace.beat;
+    const event2Duration = 1 * workspace.beat;
 
     this.moveDistance(workspace, -1);
 
@@ -1261,7 +1261,7 @@ export class PlaybackService {
     }
 
     // Calculate accidentals
-    let alteredFrequency2 = this.applyAlterations(
+    const alteredFrequency2 = this.applyAlterations(
       workspace,
       noteElement.accidental,
     );
@@ -1302,7 +1302,7 @@ export class PlaybackService {
       gorgonIndexes.push(gorgonIndex);
     }
 
-    let alteredFrequency1 = this.applyAlterations(workspace);
+    const alteredFrequency1 = this.applyAlterations(workspace);
 
     const event1: PlaybackSequenceEvent = {
       frequency: alteredFrequency1,
@@ -1319,7 +1319,7 @@ export class PlaybackService {
     // Process the apostrofos
     workspace.innerElementIndex = 1;
 
-    let event2Duration = 1 * workspace.beat;
+    const event2Duration = 1 * workspace.beat;
 
     this.moveDistance(workspace, -1);
 
@@ -1334,7 +1334,7 @@ export class PlaybackService {
     }
 
     // Calculate accidentals
-    let alteredFrequency2 = this.applyAlterations(
+    const alteredFrequency2 = this.applyAlterations(
       workspace,
       noteElement.accidental,
     );
@@ -1372,7 +1372,7 @@ export class PlaybackService {
 
     gorgonIndexes.push(gorgonIndex);
 
-    let alteredFrequency1 = this.applyAlterations(workspace);
+    const alteredFrequency1 = this.applyAlterations(workspace);
 
     const event1: PlaybackSequenceEvent = {
       frequency: alteredFrequency1,
@@ -1399,7 +1399,7 @@ export class PlaybackService {
     }
 
     // Calculate accidentals
-    let alteredFrequency2 = this.applyAlterations(
+    const alteredFrequency2 = this.applyAlterations(
       workspace,
       noteElement.accidental,
     );
@@ -1437,7 +1437,7 @@ export class PlaybackService {
 
     gorgonIndexes.push(gorgonIndex);
 
-    let alteredFrequency1 = this.applyAlterations(workspace);
+    const alteredFrequency1 = this.applyAlterations(workspace);
 
     const event1: PlaybackSequenceEvent = {
       frequency: alteredFrequency1,
@@ -1464,7 +1464,7 @@ export class PlaybackService {
     }
 
     // Calculate accidentals
-    let alteredFrequency2 = this.applyAlterations(workspace);
+    const alteredFrequency2 = this.applyAlterations(workspace);
 
     const event2: PlaybackSequenceEvent = {
       frequency: alteredFrequency2,
@@ -1493,7 +1493,7 @@ export class PlaybackService {
     }
 
     // Calculate accidentals
-    let alteredFrequencyKentimata = this.applyAlterations(
+    const alteredFrequencyKentimata = this.applyAlterations(
       workspace,
       noteElement.accidental,
     );
@@ -1538,12 +1538,12 @@ export class PlaybackService {
     }
 
     // Calculate accidentals
-    let alteredFrequency = this.applyAlterations(
+    const alteredFrequency = this.applyAlterations(
       workspace,
       noteElement.accidental,
     );
 
-    let event: PlaybackSequenceEvent = {
+    const event: PlaybackSequenceEvent = {
       frequency: alteredFrequency,
       isonFrequency: workspace.isonFrequency,
       type: 'note',
@@ -1557,7 +1557,7 @@ export class PlaybackService {
   }
 
   handleRest(noteElement: NoteElement, workspace: PlaybackWorkspace) {
-    let duration = this.restMap.get(noteElement.quantitativeNeume)!;
+    const duration = this.restMap.get(noteElement.quantitativeNeume)!;
 
     const restEvent: PlaybackSequenceEvent = {
       type: 'rest',
@@ -1679,7 +1679,7 @@ export class PlaybackService {
     events: PlaybackSequenceEvent[],
     gorgonIndexes: GorgonIndex[],
   ) {
-    for (let gorgon of gorgonIndexes) {
+    for (const gorgon of gorgonIndexes) {
       const durations = this.gorgonMap.get(gorgon.neume)!;
 
       // TODO: handle the case where the user has made an

--- a/src/services/history/CommandService.ts
+++ b/src/services/history/CommandService.ts
@@ -95,7 +95,7 @@ export class CommandService {
   }
 
   public executeAsBatch(batch: Command[]) {
-    for (let command of batch) {
+    for (const command of batch) {
       command.batchId = this.nextBatchId;
       this.execute(command);
     }
@@ -105,7 +105,7 @@ export class CommandService {
 
   public undo() {
     if (this.index >= 0) {
-      let batchId = this.commandHistory[this.index].batchId;
+      const batchId = this.commandHistory[this.index].batchId;
 
       do {
         this.commandHistory[this.index].undo();
@@ -122,7 +122,7 @@ export class CommandService {
 
   public redo() {
     if (this.index < this.commandHistory.length - 1) {
-      let batchId = this.commandHistory[this.index + 1].batchId;
+      const batchId = this.commandHistory[this.index + 1].batchId;
 
       do {
         this.index++;

--- a/src/services/history/commands/UpdatePropertiesCommand.ts
+++ b/src/services/history/commands/UpdatePropertiesCommand.ts
@@ -30,7 +30,7 @@ export class UpdatePropertiesCommand<T> implements Command {
   private updateProperties(newValues: Partial<T>) {
     const previousValues: Partial<T> = {};
 
-    for (let key of Object.keys(newValues)) {
+    for (const key of Object.keys(newValues)) {
       // Save the previous values for undo
       (previousValues as any)[key] = (this.args.target as any)[key];
 

--- a/src/services/integration/ByzHtmlExporter.ts
+++ b/src/services/integration/ByzHtmlExporter.ts
@@ -146,9 +146,9 @@ export class ByzHtmlExporter {
   }
 
   exportPageSetup(pageSetup: PageSetup) {
-    let orientation = pageSetup.landscape ? 'landscape' : 'portrait';
+    const orientation = pageSetup.landscape ? 'landscape' : 'portrait';
 
-    let style = `:root {
+    const style = `:root {
         --byz-neume-font-size: ${Unit.toPt(pageSetup.neumeDefaultFontSize)}pt;
         
         --byz-lyric-font-family: ${pageSetup.lyricsDefaultFontFamily};
@@ -555,7 +555,7 @@ export class ByzHtmlExporter {
     }
 
     if (element.lyrics.trim() != '') {
-      let lyrics = element.lyrics
+      const lyrics = element.lyrics
         .replaceAll(
           '\u{1d0b4}',
           `<${this.getTag('pelastikon')}></${this.getTag('pelastikon')}>`,

--- a/src/services/ipc/BrowserIpcService.ts
+++ b/src/services/ipc/BrowserIpcService.ts
@@ -107,7 +107,7 @@ export class BrowserIpcService implements IIpcService {
   }
 
   private async doSave(workspace: Workspace) {
-    var score = SaveService.SaveScoreToJson(workspace.score);
+    const score = SaveService.SaveScoreToJson(workspace.score);
     const data = JSON.stringify(score, null, 2);
     let file: Blob;
 
@@ -115,7 +115,7 @@ export class BrowserIpcService implements IIpcService {
     // so we always save in .byz, unless the user has already opened
     // .byzx file from the computer.
     if (workspace.filePath == null || workspace.filePath.endsWith('.byz')) {
-      var zip = new JSZip();
+      const zip = new JSZip();
 
       const fileName =
         workspace.filePath != null

--- a/src/utils/TestFileGenerator.ts
+++ b/src/utils/TestFileGenerator.ts
@@ -52,7 +52,7 @@ export abstract class TestFileGenerator {
 
     let counter = 1;
 
-    for (let q in QuantitativeNeume) {
+    for (const q in QuantitativeNeume) {
       const quantitativeNeume = q as QuantitativeNeume;
       if (
         [
@@ -64,7 +64,7 @@ export abstract class TestFileGenerator {
         continue;
       }
 
-      for (let f in Fthora) {
+      for (const f in Fthora) {
         const fthora = f as Fthora;
         if (
           fthora.startsWith('Zygos') ||
@@ -94,7 +94,7 @@ export abstract class TestFileGenerator {
 
     let counter = 1;
 
-    for (let q in QuantitativeNeume) {
+    for (const q in QuantitativeNeume) {
       const quantitativeNeume = q as QuantitativeNeume;
       if (
         [
@@ -113,7 +113,7 @@ export abstract class TestFileGenerator {
       elements.push(note);
     }
 
-    for (let q in QuantitativeNeume) {
+    for (const q in QuantitativeNeume) {
       const quantitativeNeume = q as QuantitativeNeume;
       if (
         [
@@ -132,7 +132,7 @@ export abstract class TestFileGenerator {
       elements.push(note);
     }
 
-    for (let q in QuantitativeNeume) {
+    for (const q in QuantitativeNeume) {
       const quantitativeNeume = q as QuantitativeNeume;
       if (
         [
@@ -151,7 +151,7 @@ export abstract class TestFileGenerator {
       elements.push(note);
     }
 
-    for (let q in QuantitativeNeume) {
+    for (const q in QuantitativeNeume) {
       const quantitativeNeume = q as QuantitativeNeume;
       if (
         [
@@ -178,7 +178,7 @@ export abstract class TestFileGenerator {
 
     let counter = 1;
 
-    for (let q in QuantitativeNeume) {
+    for (const q in QuantitativeNeume) {
       const quantitativeNeume = q as QuantitativeNeume;
       if (
         [
@@ -197,7 +197,7 @@ export abstract class TestFileGenerator {
       elements.push(note);
     }
 
-    for (let q in QuantitativeNeume) {
+    for (const q in QuantitativeNeume) {
       const quantitativeNeume = q as QuantitativeNeume;
       if (
         [
@@ -224,7 +224,7 @@ export abstract class TestFileGenerator {
 
     let counter = 1;
 
-    for (let q in QuantitativeNeume) {
+    for (const q in QuantitativeNeume) {
       const quantitativeNeume = q as QuantitativeNeume;
       if (
         [
@@ -243,7 +243,7 @@ export abstract class TestFileGenerator {
       elements.push(note);
     }
 
-    for (let q in QuantitativeNeume) {
+    for (const q in QuantitativeNeume) {
       const quantitativeNeume = q as QuantitativeNeume;
       if (
         [
@@ -262,7 +262,7 @@ export abstract class TestFileGenerator {
       elements.push(note);
     }
 
-    for (let q in QuantitativeNeume) {
+    for (const q in QuantitativeNeume) {
       const quantitativeNeume = q as QuantitativeNeume;
       if (
         [
@@ -289,7 +289,7 @@ export abstract class TestFileGenerator {
 
     let counter = 1;
 
-    for (let q in QuantitativeNeume) {
+    for (const q in QuantitativeNeume) {
       const quantitativeNeume = q as QuantitativeNeume;
       if (
         [
@@ -320,7 +320,7 @@ export abstract class TestFileGenerator {
       elements.push(note);
     }
 
-    for (let q in QuantitativeNeume) {
+    for (const q in QuantitativeNeume) {
       const quantitativeNeume = q as QuantitativeNeume;
       if (
         [
@@ -359,7 +359,7 @@ export abstract class TestFileGenerator {
 
     let counter = 1;
 
-    for (let q in QuantitativeNeume) {
+    for (const q in QuantitativeNeume) {
       const quantitativeNeume = q as QuantitativeNeume;
       if (
         [
@@ -378,7 +378,7 @@ export abstract class TestFileGenerator {
       elements.push(note);
     }
 
-    for (let q in QuantitativeNeume) {
+    for (const q in QuantitativeNeume) {
       const quantitativeNeume = q as QuantitativeNeume;
       if (
         [
@@ -397,7 +397,7 @@ export abstract class TestFileGenerator {
       elements.push(note);
     }
 
-    for (let q in QuantitativeNeume) {
+    for (const q in QuantitativeNeume) {
       const quantitativeNeume = q as QuantitativeNeume;
       if (
         [
@@ -416,7 +416,7 @@ export abstract class TestFileGenerator {
       elements.push(note);
     }
 
-    for (let q in QuantitativeNeume) {
+    for (const q in QuantitativeNeume) {
       const quantitativeNeume = q as QuantitativeNeume;
       if (
         [
@@ -439,7 +439,7 @@ export abstract class TestFileGenerator {
       elements.push(ison);
     }
 
-    for (let q in QuantitativeNeume) {
+    for (const q in QuantitativeNeume) {
       const quantitativeNeume = q as QuantitativeNeume;
       if (
         [
@@ -470,7 +470,7 @@ export abstract class TestFileGenerator {
 
     let counter = 1;
 
-    for (let q in QuantitativeNeume) {
+    for (const q in QuantitativeNeume) {
       const quantitativeNeume = q as QuantitativeNeume;
       if (
         [
@@ -489,7 +489,7 @@ export abstract class TestFileGenerator {
       elements.push(note);
     }
 
-    for (let q in QuantitativeNeume) {
+    for (const q in QuantitativeNeume) {
       const quantitativeNeume = q as QuantitativeNeume;
       if (
         [
@@ -516,7 +516,7 @@ export abstract class TestFileGenerator {
 
     let counter = 1;
 
-    for (let q in QuantitativeNeume) {
+    for (const q in QuantitativeNeume) {
       const quantitativeNeume = q as QuantitativeNeume;
       if (
         [
@@ -543,7 +543,7 @@ export abstract class TestFileGenerator {
 
     let counter = 1;
 
-    for (let q in QuantitativeNeume) {
+    for (const q in QuantitativeNeume) {
       const quantitativeNeume = q as QuantitativeNeume;
       if (
         [
@@ -568,7 +568,7 @@ export abstract class TestFileGenerator {
   private static generateTestFile_ModeKey() {
     const elements: ScoreElement[] = [];
 
-    for (let template of modeKeyTemplates) {
+    for (const template of modeKeyTemplates) {
       elements.push(ModeKeyElement.createFromTemplate(template));
     }
 

--- a/src/utils/getSystemFonts.ts
+++ b/src/utils/getSystemFonts.ts
@@ -58,7 +58,7 @@ async function getLinuxSystemFonts() {
 
   const fonts: string[] = [];
 
-  for (let line of stdout.split('\n')) {
+  for (const line of stdout.split('\n')) {
     const names = line.split(',');
 
     if (names.length > 1) {

--- a/src/utils/shallowEquals.ts
+++ b/src/utils/shallowEquals.ts
@@ -6,7 +6,7 @@ export const shallowEquals = (object1: any, object2: any) => {
     return false;
   }
 
-  for (let key of keys1) {
+  for (const key of keys1) {
     if (object1[key] !== object2[key]) {
       return false;
     }


### PR DESCRIPTION
Newer versions of ESLint report `const` warnings but helpfully fix them automatically via `--fix`. This PR is compatible with the current version of ESLint but unblocks a future upgrade. Regression tested with:

```bash
$ npm ci
$ npm test
$ npm run electron:build
```

Also verified that in my local branch that updates a number of dependencies, the issues in newer versions of ESLint went away.