### PR TITLE
Upgrade `electron-devtools-installer` to latest

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -30,7 +30,7 @@
       "devDependencies": {
         "@babel/preset-typescript": "^7.18.6",
         "@types/adm-zip": "^0.4.34",
-        "@types/electron-devtools-installer": "^2.2.0",
+        "@types/electron-devtools-installer": "^2.2.2",
         "@types/jest": "^27.4.0",
         "@types/node": "^17.0.2",
         "@types/throttle-debounce": "^2.1.0",
@@ -46,7 +46,7 @@
         "@vue/eslint-config-typescript": "^5.1.0",
         "electron": "^22.0.0",
         "electron-builder": "^23.6.0",
-        "electron-devtools-installer": "^3.1.0",
+        "electron-devtools-installer": "^3.2.0",
         "electron-icon-builder": "^2.0.1",
         "electron-updater": "^4.6.1",
         "eslint": "^6.8.0",
@@ -3625,9 +3625,10 @@
       }
     },
     "node_modules/@types/electron-devtools-installer": {
-      "version": "2.2.1",
-      "dev": true,
-      "license": "MIT"
+      "version": "2.2.2",
+      "resolved": "https://registry.npmjs.org/@types/electron-devtools-installer/-/electron-devtools-installer-2.2.2.tgz",
+      "integrity": "sha512-8o2XkyAw2HZoVD5KpIoUJmEgZ7BPVv33p7rY1jmn/wJUbugtQUc44vNMDTguUNUGiLv+oqgtyYmiYctHDZEzdQ==",
+      "dev": true
     },
     "node_modules/@types/eslint-visitor-keys": {
       "version": "1.0.0",
@@ -28535,7 +28536,9 @@
       }
     },
     "@types/electron-devtools-installer": {
-      "version": "2.2.1",
+      "version": "2.2.2",
+      "resolved": "https://registry.npmjs.org/@types/electron-devtools-installer/-/electron-devtools-installer-2.2.2.tgz",
+      "integrity": "sha512-8o2XkyAw2HZoVD5KpIoUJmEgZ7BPVv33p7rY1jmn/wJUbugtQUc44vNMDTguUNUGiLv+oqgtyYmiYctHDZEzdQ==",
       "dev": true
     },
     "@types/eslint-visitor-keys": {

--- a/package.json
+++ b/package.json
@@ -46,7 +46,7 @@
   "devDependencies": {
     "@babel/preset-typescript": "^7.18.6",
     "@types/adm-zip": "^0.4.34",
-    "@types/electron-devtools-installer": "^2.2.0",
+    "@types/electron-devtools-installer": "^2.2.2",
     "@types/jest": "^27.4.0",
     "@types/node": "^17.0.2",
     "@types/throttle-debounce": "^2.1.0",
@@ -62,7 +62,7 @@
     "@vue/eslint-config-typescript": "^5.1.0",
     "electron": "^22.0.0",
     "electron-builder": "^23.6.0",
-    "electron-devtools-installer": "^3.1.0",
+    "electron-devtools-installer": "^3.2.0",
     "electron-icon-builder": "^2.0.1",
     "electron-updater": "^4.6.1",
     "eslint": "^6.8.0",


### PR DESCRIPTION
Tested with

```
$ npm install
$ npm test
$ npm run electron:build
```

and opening my Axion Estin score successfully in the resulting AppImage buidl.