### PR TITLE
Upgrade Vue component dependencies from 2019 to 2021 vintages

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -20,12 +20,12 @@
         "tone": "^14.8.49",
         "uuid": "^9.0.0",
         "vue": "^2.6.14",
-        "vue-class-component": "^7.0.2",
+        "vue-class-component": "^7.2.6",
         "vue-color": "^2.8.1",
         "vue-draggable-resizable": "^2.3.0",
         "vue-observe-visibility": "^1.0.0",
-        "vue-property-decorator": "^8.3.0",
-        "vue-router": "^3.1.3"
+        "vue-property-decorator": "^8.5.1",
+        "vue-router": "^3.5.1"
       },
       "devDependencies": {
         "@babel/preset-typescript": "^7.18.6",

--- a/package.json
+++ b/package.json
@@ -36,12 +36,12 @@
     "tone": "^14.8.49",
     "uuid": "^9.0.0",
     "vue": "^2.6.14",
-    "vue-class-component": "^7.0.2",
+    "vue-class-component": "^7.2.6",
     "vue-color": "^2.8.1",
     "vue-draggable-resizable": "^2.3.0",
     "vue-observe-visibility": "^1.0.0",
-    "vue-property-decorator": "^8.3.0",
-    "vue-router": "^3.1.3"
+    "vue-property-decorator": "^8.5.1",
+    "vue-router": "^3.5.1"
   },
   "devDependencies": {
     "@babel/preset-typescript": "^7.18.6",


### PR DESCRIPTION
No breaking changes identified in the release notes:

- https://github.com/vuejs/vue-class-component/releases
- https://github.com/vuejs/vue-router/blob/dev/CHANGELOG.md
- https://github.com/kaorun343/vue-property-decorator/releases

Tested with

```
$ npm install
$ npm test
$ npm run electron:build
```

and opening my Axion Estin score successfully in the resulting AppImage build.