### PR TITLE
Upgrade `jszip` to latest

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -14,7 +14,7 @@
         "core-js": "^3.4.3",
         "html-to-image": "^1.11.11",
         "image-size": "^1.0.2",
-        "jszip": "^3.9.1",
+        "jszip": "^3.10.1",
         "mime-types": "^2.1.35",
         "register-service-worker": "^1.7.2",
         "tone": "^14.8.49",
@@ -18762,13 +18762,14 @@
       }
     },
     "node_modules/jszip": {
-      "version": "3.9.1",
-      "license": "(MIT OR GPL-3.0-or-later)",
+      "version": "3.10.1",
+      "resolved": "https://registry.npmjs.org/jszip/-/jszip-3.10.1.tgz",
+      "integrity": "sha512-xXDvecyTpGLrqFrvkrUSoxxfJI5AH7U8zxxtVclpsUtMCq4JQ290LY8AW5c7Ggnr/Y/oK+bQMbqK2qmtk3pN4g==",
       "dependencies": {
         "lie": "~3.3.0",
         "pako": "~1.0.2",
         "readable-stream": "~2.3.6",
-        "set-immediate-shim": "~1.0.1"
+        "setimmediate": "^1.0.5"
       }
     },
     "node_modules/kew": {
@@ -23481,13 +23482,6 @@
       "dev": true,
       "license": "ISC"
     },
-    "node_modules/set-immediate-shim": {
-      "version": "1.0.1",
-      "license": "MIT",
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
     "node_modules/set-value": {
       "version": "2.0.1",
       "dev": true,
@@ -23523,7 +23517,6 @@
     },
     "node_modules/setimmediate": {
       "version": "1.0.5",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/setprototypeof": {
@@ -42700,12 +42693,14 @@
       }
     },
     "jszip": {
-      "version": "3.9.1",
+      "version": "3.10.1",
+      "resolved": "https://registry.npmjs.org/jszip/-/jszip-3.10.1.tgz",
+      "integrity": "sha512-xXDvecyTpGLrqFrvkrUSoxxfJI5AH7U8zxxtVclpsUtMCq4JQ290LY8AW5c7Ggnr/Y/oK+bQMbqK2qmtk3pN4g==",
       "requires": {
         "lie": "~3.3.0",
         "pako": "~1.0.2",
         "readable-stream": "~2.3.6",
-        "set-immediate-shim": "~1.0.1"
+        "setimmediate": "^1.0.5"
       }
     },
     "kew": {
@@ -46121,9 +46116,6 @@
       "version": "2.0.0",
       "dev": true
     },
-    "set-immediate-shim": {
-      "version": "1.0.1"
-    },
     "set-value": {
       "version": "2.0.1",
       "dev": true,
@@ -46148,8 +46140,7 @@
       }
     },
     "setimmediate": {
-      "version": "1.0.5",
-      "dev": true
+      "version": "1.0.5"
     },
     "setprototypeof": {
       "version": "1.2.0",

--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
     "core-js": "^3.4.3",
     "html-to-image": "^1.11.11",
     "image-size": "^1.0.2",
-    "jszip": "^3.9.1",
+    "jszip": "^3.10.1",
     "mime-types": "^2.1.35",
     "register-service-worker": "^1.7.2",
     "tone": "^14.8.49",


### PR DESCRIPTION
No breaking changes identified in [the release notes](https://github.com/Stuk/jszip/blob/main/CHANGES.md). Tested with

```
$ npm install
$ npm test
$ npm run electron:build
```

and opening my Axion Estin score successfully in the resulting AppImage build.