### PR TITLE
Remove unused `core-js` dependency

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11,7 +11,6 @@
       "license": "GPL-3.0",
       "dependencies": {
         "@types/mime-types": "^2.1.1",
-        "core-js": "^3.4.3",
         "html-to-image": "^1.11.11",
         "image-size": "^1.0.2",
         "jszip": "^3.10.1",
@@ -9764,6 +9763,7 @@
     },
     "node_modules/core-js": {
       "version": "3.21.0",
+      "dev": true,
       "hasInstallScript": true,
       "license": "MIT",
       "funding": {
@@ -36470,7 +36470,8 @@
       }
     },
     "core-js": {
-      "version": "3.21.0"
+      "version": "3.21.0",
+      "dev": true
     },
     "core-js-compat": {
       "version": "3.21.0",

--- a/package.json
+++ b/package.json
@@ -27,7 +27,6 @@
   "main": "background.js",
   "dependencies": {
     "@types/mime-types": "^2.1.1",
-    "core-js": "^3.4.3",
     "html-to-image": "^1.11.11",
     "image-size": "^1.0.2",
     "jszip": "^3.10.1",


### PR DESCRIPTION
I could not find any usages of this old dependency, so keeping it in the dependency tree seems like a liability. Therefore I am removing it in this PR. If it does need to be retained for some reason, I can close this PR and open a new PR to upgrade it to the latest version instead. Tested with

```
$ npm install
$ npm test
$ npm run electron:build
```

and opening my Axion Estin score successfully in the resulting AppImage build.