### PR TITLE
Upgrade `vue-router` from 3.5.1 to 3.6.5

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -24,7 +24,7 @@
         "vue-draggable-resizable": "^2.3.0",
         "vue-observe-visibility": "^1.0.0",
         "vue-property-decorator": "^8.5.1",
-        "vue-router": "^3.5.1"
+        "vue-router": "^3.6.5"
       },
       "devDependencies": {
         "@babel/preset-typescript": "^7.18.6",

--- a/package.json
+++ b/package.json
@@ -40,7 +40,7 @@
     "vue-draggable-resizable": "^2.3.0",
     "vue-observe-visibility": "^1.0.0",
     "vue-property-decorator": "^8.5.1",
-    "vue-router": "^3.5.1"
+    "vue-router": "^3.6.5"
   },
   "devDependencies": {
     "@babel/preset-typescript": "^7.18.6",


### PR DESCRIPTION
I had trouble upgrading this previously under Vue 2.6, but under Vue 2.7 the upgrade went smoothly. The [changelogs](https://github.com/vuejs/vue-router/blob/dev/CHANGELOG.md) did not reveal anything of concern. Tested with

```
$ npm install
$ npm test
$ npm run electron:build
```

and opening my Axion Estin score successfully in the resulting AppImage build.