### PR TITLE
Upgrade `vue-property-decorator` from 8.5.1 to 9.1.2

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -23,7 +23,7 @@
         "vue-color": "^2.8.1",
         "vue-draggable-resizable": "^2.3.0",
         "vue-observe-visibility": "^1.0.0",
-        "vue-property-decorator": "^8.5.1",
+        "vue-property-decorator": "^9.1.2",
         "vue-router": "^3.6.5"
       },
       "devDependencies": {
@@ -30706,14 +30706,12 @@
       "integrity": "sha512-s5TFh3s3h3Mhd3jaz3zGzkVHKHnc/0C/gNr30olO99+yw2hl3WBhK3ng3/f9OF+qkW4+l7GkmwfAzDAcY3lCFg=="
     },
     "node_modules/vue-property-decorator": {
-      "version": "8.5.1",
-      "resolved": "https://registry.npmjs.org/vue-property-decorator/-/vue-property-decorator-8.5.1.tgz",
-      "integrity": "sha512-O6OUN2OMsYTGPvgFtXeBU3jPnX5ffQ9V4I1WfxFQ6dqz6cOUbR3Usou7kgFpfiXDvV7dJQSFcJ5yUPgOtPPm1Q==",
-      "dependencies": {
-        "vue-class-component": "^7.1.0"
-      },
+      "version": "9.1.2",
+      "resolved": "https://registry.npmjs.org/vue-property-decorator/-/vue-property-decorator-9.1.2.tgz",
+      "integrity": "sha512-xYA8MkZynPBGd/w5QFJ2d/NM0z/YeegMqYTphy7NJQXbZcuU6FC6AOdUAcy4SXP+YnkerC6AfH+ldg7PDk9ESQ==",
       "peerDependencies": {
-        "vue": "*"
+        "vue": "*",
+        "vue-class-component": "*"
       }
     },
     "node_modules/vue-router": {
@@ -57234,12 +57232,10 @@
       "integrity": "sha512-s5TFh3s3h3Mhd3jaz3zGzkVHKHnc/0C/gNr30olO99+yw2hl3WBhK3ng3/f9OF+qkW4+l7GkmwfAzDAcY3lCFg=="
     },
     "vue-property-decorator": {
-      "version": "8.5.1",
-      "resolved": "https://registry.npmjs.org/vue-property-decorator/-/vue-property-decorator-8.5.1.tgz",
-      "integrity": "sha512-O6OUN2OMsYTGPvgFtXeBU3jPnX5ffQ9V4I1WfxFQ6dqz6cOUbR3Usou7kgFpfiXDvV7dJQSFcJ5yUPgOtPPm1Q==",
-      "requires": {
-        "vue-class-component": "^7.1.0"
-      }
+      "version": "9.1.2",
+      "resolved": "https://registry.npmjs.org/vue-property-decorator/-/vue-property-decorator-9.1.2.tgz",
+      "integrity": "sha512-xYA8MkZynPBGd/w5QFJ2d/NM0z/YeegMqYTphy7NJQXbZcuU6FC6AOdUAcy4SXP+YnkerC6AfH+ldg7PDk9ESQ==",
+      "requires": {}
     },
     "vue-router": {
       "version": "3.6.5",

--- a/package.json
+++ b/package.json
@@ -39,7 +39,7 @@
     "vue-color": "^2.8.1",
     "vue-draggable-resizable": "^2.3.0",
     "vue-observe-visibility": "^1.0.0",
-    "vue-property-decorator": "^8.5.1",
+    "vue-property-decorator": "^9.1.2",
     "vue-router": "^3.6.5"
   },
   "devDependencies": {


### PR DESCRIPTION
The [changelog](https://github.com/kaorun343/vue-property-decorator/blob/master/CHANGELOG.md) did not reveal any breaking changes. Tested with

```
$ npm install
$ npm test
$ npm run electron:build
```

and opening my Axion Estin score successfully in the resulting AppImage build.