### PR TITLE
Remove unused `@types/adm-zip` dependency

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -28,7 +28,6 @@
       },
       "devDependencies": {
         "@babel/preset-typescript": "^7.18.6",
-        "@types/adm-zip": "^0.4.34",
         "@types/electron-devtools-installer": "^2.2.2",
         "@types/jest": "^28.1.3",
         "@types/node": "^17.0.2",
@@ -4224,15 +4223,6 @@
       "version": "1.3.5",
       "resolved": "https://registry.npmjs.org/@types/accepts/-/accepts-1.3.5.tgz",
       "integrity": "sha512-jOdnI/3qTpHABjM5cx1Hc0sKsPoYCp+DP/GJRGtDlPd7fiV9oXGGIcjW/ZOxLIvjGz8MA+uMZI9metHlgqbgwQ==",
-      "dev": true,
-      "dependencies": {
-        "@types/node": "*"
-      }
-    },
-    "node_modules/@types/adm-zip": {
-      "version": "0.4.34",
-      "resolved": "https://registry.npmjs.org/@types/adm-zip/-/adm-zip-0.4.34.tgz",
-      "integrity": "sha512-8ToYLLAYhkRfcmmljrKi22gT2pqu7hGMDtORP1emwIEGmgUTZOsaDjzWFzW5N2frcFRz/50CWt4zA1CxJ73pmQ==",
       "dev": true,
       "dependencies": {
         "@types/node": "*"
@@ -36173,15 +36163,6 @@
       "version": "1.3.5",
       "resolved": "https://registry.npmjs.org/@types/accepts/-/accepts-1.3.5.tgz",
       "integrity": "sha512-jOdnI/3qTpHABjM5cx1Hc0sKsPoYCp+DP/GJRGtDlPd7fiV9oXGGIcjW/ZOxLIvjGz8MA+uMZI9metHlgqbgwQ==",
-      "dev": true,
-      "requires": {
-        "@types/node": "*"
-      }
-    },
-    "@types/adm-zip": {
-      "version": "0.4.34",
-      "resolved": "https://registry.npmjs.org/@types/adm-zip/-/adm-zip-0.4.34.tgz",
-      "integrity": "sha512-8ToYLLAYhkRfcmmljrKi22gT2pqu7hGMDtORP1emwIEGmgUTZOsaDjzWFzW5N2frcFRz/50CWt4zA1CxJ73pmQ==",
       "dev": true,
       "requires": {
         "@types/node": "*"

--- a/package.json
+++ b/package.json
@@ -44,7 +44,6 @@
   },
   "devDependencies": {
     "@babel/preset-typescript": "^7.18.6",
-    "@types/adm-zip": "^0.4.34",
     "@types/electron-devtools-installer": "^2.2.2",
     "@types/jest": "^28.1.3",
     "@types/node": "^17.0.2",


### PR DESCRIPTION
I could not find any usages of this old dependency, so keeping it in the dependency tree seems like a liability. Therefore I am removing it in this PR. If it does need to be retained for some reason, I can close this PR and open a new PR to upgrade it to the latest version instead. Tested with

```
$ npm install
$ npm test
$ npm run electron:build
```

and opening my Axion Estin score successfully in the resulting AppImage build.