### PR TITLE
Migrate to an external event emitter library

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -15,6 +15,7 @@
         "image-size": "^1.0.2",
         "jszip": "^3.10.1",
         "mime-types": "^2.1.35",
+        "mitt": "^3.0.0",
         "register-service-worker": "^1.7.2",
         "tone": "^14.8.49",
         "uuid": "^9.0.0",
@@ -21799,6 +21800,11 @@
       "engines": {
         "node": ">=4.0.0"
       }
+    },
+    "node_modules/mitt": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/mitt/-/mitt-3.0.0.tgz",
+      "integrity": "sha512-7dX2/10ITVyqh4aOSVI9gdape+t9l2/8QxHrFmUXu4EEUpdlxl6RudZUPZoc+zuY2hk1j7XxVroIVIan/pD/SQ=="
     },
     "node_modules/mixin-deep": {
       "version": "1.3.2",
@@ -50024,6 +50030,11 @@
         "stream-each": "^1.1.0",
         "through2": "^2.0.0"
       }
+    },
+    "mitt": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/mitt/-/mitt-3.0.0.tgz",
+      "integrity": "sha512-7dX2/10ITVyqh4aOSVI9gdape+t9l2/8QxHrFmUXu4EEUpdlxl6RudZUPZoc+zuY2hk1j7XxVroIVIan/pD/SQ=="
     },
     "mixin-deep": {
       "version": "1.3.2",

--- a/package.json
+++ b/package.json
@@ -31,6 +31,7 @@
     "image-size": "^1.0.2",
     "jszip": "^3.10.1",
     "mime-types": "^2.1.35",
+    "mitt": "^3.0.0",
     "register-service-worker": "^1.7.2",
     "tone": "^14.8.49",
     "uuid": "^9.0.0",

--- a/src/eventBus.ts
+++ b/src/eventBus.ts
@@ -1,2 +1,9 @@
-import Vue from 'vue';
-export const EventBus = new Vue();
+import mitt from 'mitt';
+const emitter = mitt();
+export const EventBus = {
+  $on: (eventName: string, func: (...args: any[]) => unknown) =>
+    emitter.on(eventName, func),
+  $off: (eventName: string, func: (...args: any[]) => unknown) =>
+    emitter.off(eventName, func),
+  $emit: (type: string, event?: unknown) => emitter.emit(type, event),
+};


### PR DESCRIPTION
As a prerequisite to #117, migrate from the event bus pattern (which has been [removed in Vue 3](https://v3-migration.vuejs.org/breaking-changes/events-api.html)) to the [Mitt](https://github.com/developit/mitt) library.

Tested with

```
$ npm install
$ npm test
$ npm run electron:build
```

and opening my Axion Estin score successfully, after which I set a breakpoint on every call to `EventBus.${emit,on,off}` as well as their callbacks and exercised each feature in the UI manually, removing each breakpoint as I hit it in the debugger until there were no breakpoints left that had not been exercised.

Fixes #137