### PR TITLE
Constify Vue templates

### DIFF
--- a/src/components/Editor.vue
+++ b/src/components/Editor.vue
@@ -2822,7 +2822,7 @@ export default class Editor extends Vue {
 
     let currentIndex = this.selectedElementIndex;
 
-    for (let clipboardElement of this.clipboard) {
+    for (const clipboardElement of this.clipboard) {
       const currentElement = this.elements[currentIndex];
 
       if (currentIndex >= this.elements.length - 1) {
@@ -3436,7 +3436,7 @@ export default class Editor extends Vue {
       (x) => x.hasUnsavedChanges,
     );
 
-    for (let workspace of unsavedWorkspaces) {
+    for (const workspace of unsavedWorkspaces) {
       if (!(await this.closeWorkspace(workspace))) {
         await this.ipcService.cancelExit();
         return false;
@@ -3476,7 +3476,7 @@ export default class Editor extends Vue {
     // Force neumes to be an array if it's not
     neumes = Array.isArray(neumes) ? neumes : [neumes];
 
-    for (let neume of neumes) {
+    for (const neume of neumes) {
       if (
         neume === GorgonNeume.Gorgon_Bottom &&
         onlyTakesTopGorgon(element.quantitativeNeume)
@@ -3515,7 +3515,7 @@ export default class Editor extends Vue {
   private setFthoraNote(element: NoteElement, neumes: Fthora[]) {
     let equivalent = false;
 
-    for (let neume of neumes) {
+    for (const neume of neumes) {
       // If previous neume was matched, set to the next neume in the cycle
       if (equivalent) {
         this.updateNoteFthora(element, neume);
@@ -3705,7 +3705,7 @@ export default class Editor extends Vue {
   private setTie(element: NoteElement, neumes: Tie[]) {
     let equivalent = false;
 
-    for (let neume of neumes) {
+    for (const neume of neumes) {
       // If previous neume was matched, set to the next neume in the cycle
       if (equivalent) {
         this.updateNoteTie(element, neume);
@@ -4768,7 +4768,7 @@ export default class Editor extends Vue {
 
           let pageNumber = 1;
 
-          for (let page of pages) {
+          for (const page of pages) {
             const options = {
               fontEmbedCSS,
               pixelRatio: args.dpi / 96,

--- a/src/components/FileMenuBar.vue
+++ b/src/components/FileMenuBar.vue
@@ -197,7 +197,7 @@ export default class FileMenuBar extends Vue {
     const files = this.fileSelector.files!;
 
     if (files.length > 0) {
-      var file = files[0];
+      const file = files[0];
 
       if (file.name.endsWith('.byz')) {
         const zip = await JSZip.loadAsync(file);
@@ -213,7 +213,7 @@ export default class FileMenuBar extends Vue {
         // the same file twice, it will load
         this.fileSelector.value = '';
       } else {
-        var reader = new FileReader();
+        const reader = new FileReader();
 
         reader.onload = () => {
           EventBus.$emit(IpcMainChannels.FileMenuOpenScore, {
@@ -236,9 +236,9 @@ export default class FileMenuBar extends Vue {
     const files = this.imageFileSelector.files!;
 
     if (files.length > 0) {
-      var file = files[0];
+      const file = files[0];
 
-      var reader = new FileReader();
+      const reader = new FileReader();
 
       reader.onload = () => {
         const data = reader.result as string;

--- a/src/components/InputUnit.vue
+++ b/src/components/InputUnit.vue
@@ -56,7 +56,7 @@ export default class InputUnit extends Vue {
   }
 
   get displayValue() {
-    let convertedValue = this.toDisplay(this.modelValue);
+    const convertedValue = this.toDisplay(this.modelValue);
 
     return this.precision != null
       ? convertedValue.toFixed(this.precision)

--- a/src/components/ModeKeyDialog.vue
+++ b/src/components/ModeKeyDialog.vue
@@ -122,7 +122,7 @@ export default class ModeKeyDialog extends Vue {
       `${elements[0].fontSize}px ${this.pageSetup.neumeDefaultFontFamily}`,
     );
 
-    for (let element of elements) {
+    for (const element of elements) {
       element.height = height;
       element.computedFontFamily = this.pageSetup.neumeDefaultFontFamily;
     }


### PR DESCRIPTION
This PR was generated automatically with ESLint. While playing with some more strict ESLint settings, I found that ESLint is now able to detect more values that are never reassigned, for which it prefers `const` (`prefer-const`). This PR applies the suggested fixes to prepare us for eventually moving to a more strict ESLint configuration in the future. Tested with

```
$ npm install
$ npm test
$ npm run build
$ npm run lint
```