### PR TITLE
Add close options to File menu

### DIFF
--- a/electron/main/index.ts
+++ b/electron/main/index.ts
@@ -14,6 +14,8 @@ import {
 import { autoUpdater } from 'electron-updater';
 import installExtension, { VUEJS_DEVTOOLS } from 'electron-devtools-installer';
 import {
+  CloseWorkspacesArgs,
+  CloseWorkspacesDisposition,
   IpcMainChannels,
   IpcRendererChannels,
   ShowMessageBoxArgs,
@@ -968,6 +970,24 @@ function createMenu() {
           accelerator: 'CmdOrCtrl+P',
           click() {
             win?.webContents.send(IpcMainChannels.FileMenuPrint);
+          },
+        },
+        { type: 'separator' },
+        {
+          label: '&Close',
+          accelerator: 'CmdOrCtrl+W',
+          click() {
+            win?.webContents.send(IpcMainChannels.CloseWorkspaces, {
+              disposition: CloseWorkspacesDisposition.SELF,
+            } as CloseWorkspacesArgs);
+          },
+        },
+        {
+          label: 'Close Ot&hers',
+          click() {
+            win?.webContents.send(IpcMainChannels.CloseWorkspaces, {
+              disposition: CloseWorkspacesDisposition.OTHERS,
+            } as CloseWorkspacesArgs);
           },
         },
         { type: 'separator' },

--- a/src/components/FileMenuBar.vue
+++ b/src/components/FileMenuBar.vue
@@ -12,6 +12,9 @@
       <div class="separator" />
       <FileMenuItem label="Page Setup" @click="onClickPageSetup" />
       <FileMenuItem label="Export as HTML" @click="onClickExportAsHtml" />
+      <div class="separator" />
+      <FileMenuItem label="Close" @click="onClickClose" />
+      <FileMenuItem label="Close Others" @click="onClickCloseOthers" />
     </FileMenuBarItem>
     <FileMenuBarItem
       label="Edit"
@@ -86,6 +89,8 @@ import FileMenuBarItem from '@/components/FileMenuBarItem.vue';
 import FileMenuItem from '@/components/FileMenuItem.vue';
 import { EventBus } from '@/eventBus';
 import {
+  CloseWorkspacesArgs,
+  CloseWorkspacesDisposition,
   FileMenuInsertTextboxArgs,
   FileMenuOpenImageArgs,
   FileMenuOpenScoreArgs,
@@ -190,6 +195,20 @@ export default class FileMenuBar extends Vue {
 
   onClickPageSetup() {
     EventBus.$emit(IpcMainChannels.FileMenuPageSetup);
+    this.isMenuOpen = false;
+  }
+
+  onClickClose() {
+    EventBus.$emit(IpcMainChannels.CloseWorkspaces, {
+      disposition: CloseWorkspacesDisposition.SELF,
+    } as CloseWorkspacesArgs);
+    this.isMenuOpen = false;
+  }
+
+  onClickCloseOthers() {
+    EventBus.$emit(IpcMainChannels.CloseWorkspaces, {
+      disposition: CloseWorkspacesDisposition.OTHERS,
+    } as CloseWorkspacesArgs);
     this.isMenuOpen = false;
   }
 

--- a/src/ipc/ipcChannels.ts
+++ b/src/ipc/ipcChannels.ts
@@ -35,6 +35,8 @@ export enum IpcMainChannels {
 
   FileMenuGenerateTestFile = 'GenerateTestFile',
 
+  CloseWorkspaces = 'CloseWorkspaces',
+
   CloseApplication = 'CloseApplication',
 }
 
@@ -150,4 +152,15 @@ export interface ExportPageAsImageArgs {
 export interface PrintWorkspaceArgs {
   pageSize: PageSize;
   landscape: boolean;
+}
+
+export enum CloseWorkspacesDisposition {
+  SELF,
+  OTHERS,
+  LEFT,
+  RIGHT,
+}
+
+export interface CloseWorkspacesArgs {
+  disposition: CloseWorkspacesDisposition;
 }


### PR DESCRIPTION
Adds "Close" and "Close others" to the File menu in both the Electron application and the web application. I also implemented support for closing tabs to the left and to the right of the current tab, but I thought it might clutter the File menu too much to expose them there. Perhaps they could be exposed in the tab container in the future. Tested interactively in the Electron application.