### PR TITLE
Fix rest duration

### DIFF
--- a/src/services/audio/PlaybackService.ts
+++ b/src/services/audio/PlaybackService.ts
@@ -1560,7 +1560,7 @@ export class PlaybackService {
     const restEvent: PlaybackSequenceEvent = {
       type: 'rest',
       bpm: workspace.bpm,
-      duration,
+      duration: duration * workspace.beat,
       transportTime: 0,
       elementIndex: workspace.elementIndex,
     };


### PR DESCRIPTION
Before this PR, rests played back at twice the duration of other notes. Now they play back at the correct duration.