### PR TITLE
Playback improvements

### DIFF
--- a/src/services/audio/PlaybackService.ts
+++ b/src/services/audio/PlaybackService.ts
@@ -1632,8 +1632,6 @@ export class PlaybackService {
     workspace.enharmonicZo = workspace.permanentEnharmonicZo;
     workspace.enharmonicGa = false;
     workspace.enharmonicVou = workspace.permanentEnharmonicVou;
-    workspace.generalFlat = false;
-    workspace.generalSharp = false;
   }
 
   handleTempo(tempoElement: TempoElement, workspace: PlaybackWorkspace) {

--- a/src/services/audio/PlaybackService.ts
+++ b/src/services/audio/PlaybackService.ts
@@ -291,6 +291,10 @@ export class PlaybackService {
           ) {
             workspace.generalFlat = true;
             workspace.enharmonicZo = false;
+            if (workspace.scale.name !== PlaybackScaleName.Diatonic) {
+              // General flat implies a switch to the diatonic scale
+              this.switchToDiatonic(workspace);
+            }
           } else if (
             noteElement.fthora === Fthora.GeneralSharp_Top ||
             noteElement.fthora === Fthora.GeneralSharp_Bottom
@@ -298,6 +302,10 @@ export class PlaybackService {
             workspace.generalSharp = true;
             workspace.enharmonicGa = false;
             workspace.enharmonicVou = false;
+            if (workspace.scale.name !== PlaybackScaleName.Diatonic) {
+              // General sharp implies a switch to the diatonic scale
+              this.switchToDiatonic(workspace);
+            }
           } else {
             workspace.enharmonicZo = workspace.permanentEnharmonicZo;
             workspace.enharmonicGa = false;
@@ -664,6 +672,12 @@ export class PlaybackService {
     } else {
       workspace.noteOffset = 0;
     }
+  }
+
+  switchToDiatonic(workspace: PlaybackWorkspace) {
+    const note = this.scaleNoteMap.get(workspace.note);
+    workspace.scale = this.diatonicScale;
+    workspace.intervalIndex = this.diatonicScale.scaleNoteMap.get(note!)!;
   }
 
   applyAlterations(
@@ -1592,11 +1606,7 @@ export class PlaybackService {
       !workspace.permanentEnharmonicVou
     ) {
       // Clear the enharmonic fthora
-      const note = this.scaleNoteMap.get(workspace.note);
-
-      workspace.scale = this.diatonicScale;
-
-      workspace.intervalIndex = this.diatonicScale.scaleNoteMap.get(note!)!;
+      this.switchToDiatonic(workspace);
     }
 
     if (!martyriaElement.auto) {

--- a/src/services/audio/PlaybackService.ts
+++ b/src/services/audio/PlaybackService.ts
@@ -1642,6 +1642,8 @@ export class PlaybackService {
     workspace.enharmonicZo = workspace.permanentEnharmonicZo;
     workspace.enharmonicGa = false;
     workspace.enharmonicVou = workspace.permanentEnharmonicVou;
+    workspace.generalFlat = false;
+    workspace.generalSharp = false;
   }
 
   handleTempo(tempoElement: TempoElement, workspace: PlaybackWorkspace) {


### PR DESCRIPTION
I typed up the Chourmouzios score from https://github.com/danielgarthur/neanes/issues/217#issuecomment-1676737958 and played it back. There were two issues:

- The general sharps and flats were being reset at martyrias, but these are supposed to be permanent.
- General sharps and flats apparently imply a switch to the diatonic scale, as noted in #217.

With that, the score now plays back correctly (as long as Diatonic Zo attraction is disabled).

![Chourmouzios-1](https://github.com/danielgarthur/neanes/assets/29850/9264d0b6-381d-474e-8be5-316c8d58671a)


Fixes #217