### PR TITLE
Adapt to commit a7d3b98

### DIFF
--- a/src/models/NeumeValues.ts
+++ b/src/models/NeumeValues.ts
@@ -134,7 +134,6 @@ export function getSpreadIndex(
     case QuantitativeNeume.OligonPlusKentemataPlusHypsiliLeft:
     case QuantitativeNeume.OligonPlusKentemataPlusHypsiliRight:
     case QuantitativeNeume.OligonPlusKentemata:
-      // TODO (#253) Add support for fthora above oligon that applies to oligon rather than kentemata
       if (neumeSelection === NeumeSelection.Primary) {
         if (fthora.endsWith('_Top')) {
           return 1;
@@ -144,7 +143,11 @@ export function getSpreadIndex(
           return -1; // Undefined
         }
       } else if (neumeSelection === NeumeSelection.Secondary) {
-        return -1; // Undefined
+        if (neume === QuantitativeNeume.OligonPlusKentemata) {
+          return 0;
+        } else {
+          return -1; // Undefined
+        }
       } else if (neumeSelection === NeumeSelection.Tertiary) {
         return -1; // Undefined
       }


### PR DESCRIPTION
Amends #252 to adapt to commit a7d3b98. With that, these two verses of Makarios Anhr can now make it through the layout service correctly:

![Makarios Anhr-1](https://github.com/danielgarthur/neanes/assets/29850/67088349-ddb1-470e-973c-ffa1b7a6e56c)

They still don't play back correctly, but that will have to be a bug for another day...