### PR TITLE
Improve playback service

### DIFF
--- a/src/components/Editor.vue
+++ b/src/components/Editor.vue
@@ -4109,11 +4109,6 @@ export default class Editor extends Vue {
       fthora === Fthora.HardChromaticPa_Bottom
     ) {
       chromaticFthoraNote = ScaleNote.Pa;
-    } else if (
-      fthora === Fthora.Enharmonic_Top ||
-      fthora === Fthora.Enharmonic_Bottom
-    ) {
-      chromaticFthoraNote = ScaleNote.Ga;
     }
 
     this.updateNote(element, { fthora, chromaticFthoraNote });

--- a/src/components/ToolbarNeume.vue
+++ b/src/components/ToolbarNeume.vue
@@ -816,20 +816,10 @@ export default class ToolbarNeume extends Vue {
     return [];
   }
 
-  get hasAmbiguousEnharmonicFthora() {
-    return (
-      (this.element.fthora === Fthora.Enharmonic_Top ||
-        this.element.fthora === Fthora.Enharmonic_Bottom) &&
-      this.element.scaleNotes.includes(ScaleNote.Ga) &&
-      this.element.scaleNotes.includes(ScaleNote.Vou)
-    );
-  }
-
   get showChromaticFthoraNote() {
     return (
       this.element.fthora != null &&
-      (this.chromaticFthoras.includes(this.element.fthora) ||
-        this.hasAmbiguousEnharmonicFthora)
+      this.chromaticFthoras.includes(this.element.fthora)
     );
   }
 

--- a/src/models/ModeKeys.ts
+++ b/src/models/ModeKeys.ts
@@ -347,6 +347,7 @@ export const modeKeyTemplates: ModeKeyTemplate[] = [
     scale: Scale.Diatonic,
     scaleNote: ScaleNote.Zo,
     description: 'Enharmonic',
+    fthora: Fthora.Enharmonic_Top,
     martyria: ModeSign.VarysZo,
     note: ModeSign.Zo,
     fthoraAboveNote: Fthora.Enharmonic_Top,

--- a/src/services/LayoutService.ts
+++ b/src/services/LayoutService.ts
@@ -1795,7 +1795,7 @@ export class LayoutService {
     return rootSign;
   }
 
-  private static getScaleFromFthora(fthora: Fthora, currentNote: number) {
+  public static getScaleFromFthora(fthora: Fthora, currentNote: number) {
     if (
       fthora.startsWith('Diatonic') ||
       fthora.startsWith('GeneralSharp') ||
@@ -1853,7 +1853,7 @@ export class LayoutService {
     return null;
   }
 
-  private static getShift(
+  public static getShift(
     currentNote: number,
     currentScale: Scale,
     fthora: Fthora,
@@ -1868,7 +1868,7 @@ export class LayoutService {
       );
 
       shift = fthoraNote - currentNote;
-      shift = shift % 4;
+      shift %= 4;
     } else if (currentScale === Scale.SoftChromatic) {
       const fthoraNote = getScaleNoteValue(
         chromaticFthoraNote ??
@@ -1876,7 +1876,7 @@ export class LayoutService {
       );
 
       shift = fthoraNote - currentNote;
-      shift = shift % 4;
+      shift %= 4;
     } else if (currentScale === Scale.Diatonic) {
       let fthoraNote = currentNote;
 

--- a/src/services/audio/AnalysisService.ts
+++ b/src/services/audio/AnalysisService.ts
@@ -1,0 +1,962 @@
+import {
+  ElementType,
+  MartyriaElement,
+  ModeKeyElement,
+  NoteElement,
+  ScoreElement,
+  TempoElement,
+} from '@/models/Element';
+import {
+  Accidental,
+  Fthora,
+  GorgonNeume,
+  Ison,
+  QuantitativeNeume,
+  TempoSign,
+  TimeNeume,
+} from '@/models/Neumes';
+import { getNeumeValue, getNoteSpread } from '@/models/NeumeValues';
+import {
+  getNoteValue,
+  getScaleNoteFromValue,
+  getScaleNoteValue,
+  Scale,
+  ScaleNote,
+} from '@/models/Scales';
+
+import { LayoutService } from '../LayoutService';
+
+export interface AnalysisNode {
+  nodeType: NodeType;
+  elementIndex: number;
+}
+
+export interface PitchNode extends AnalysisNode {
+  physicalNote: ScaleNote;
+  virtualNote: ScaleNote;
+  scale: Scale;
+}
+
+export interface TemporalNode extends AnalysisNode {
+  duration: number;
+}
+
+export enum NodeType {
+  NoteAtomNode = 'NoteAtomNode',
+  RestNode = 'RestNode',
+  ModeKeyNode = 'ModeKeyNode',
+  FthoraNode = 'FthoraNode',
+  IsonNode = 'IsonNode',
+  TempoNode = 'TempoNode',
+}
+
+export class NoteAtomNode implements PitchNode, TemporalNode {
+  public readonly nodeType: NodeType = NodeType.NoteAtomNode;
+  public elementIndex: number = 0;
+  public physicalNote: ScaleNote = ScaleNote.Pa;
+  public virtualNote: ScaleNote = ScaleNote.Pa;
+  public scale: Scale = Scale.Diatonic;
+  public duration: number = 0;
+  public ignoreAttractions: boolean = false;
+  public accidental: Accidental | null = null;
+}
+
+export class RestNode implements TemporalNode {
+  public readonly nodeType: NodeType = NodeType.RestNode;
+  public elementIndex: number = 0;
+  public duration: number = 0;
+}
+
+export class ModeKeyNode implements PitchNode {
+  public readonly nodeType: NodeType = NodeType.ModeKeyNode;
+  public elementIndex: number = 0;
+  public physicalNote: ScaleNote = ScaleNote.Pa;
+  public virtualNote: ScaleNote = ScaleNote.Pa;
+  public scale: Scale = Scale.Diatonic;
+  public ignoreAttractions: boolean = false;
+  public permanentEnharmonicZo: boolean = false;
+  public legetos: boolean = false;
+}
+
+export class FthoraNode implements PitchNode {
+  public readonly nodeType: NodeType = NodeType.FthoraNode;
+  public elementIndex: number = 0;
+  public physicalNote: ScaleNote = ScaleNote.Pa;
+  public virtualNote: ScaleNote = ScaleNote.Pa;
+  public scale: Scale = Scale.Diatonic;
+  public generalFlat: boolean = false;
+  public generalSharp: boolean = false;
+}
+
+export class IsonNode implements AnalysisNode {
+  public readonly nodeType: NodeType = NodeType.IsonNode;
+  public elementIndex: number = 0;
+  public ison: Ison = Ison.Pa;
+}
+
+export class TempoNode implements AnalysisNode {
+  public readonly nodeType: NodeType = NodeType.TempoNode;
+  public elementIndex: number = 0;
+  public bpm: number = 0;
+}
+
+interface AnalysisWorkspace {
+  nodes: AnalysisNode[];
+  gorgonIndexes: GorgonIndex[];
+
+  currentNote: number;
+  currentScale: Scale;
+  currentShift: number;
+}
+
+interface GorgonIndex {
+  index: number;
+  neume: GorgonNeume;
+}
+
+export class AnalysisService {
+  public static analyze(elements: ScoreElement[]): AnalysisNode[] {
+    const workspace: AnalysisWorkspace = {
+      nodes: [],
+      gorgonIndexes: [],
+
+      currentNote: 0,
+      currentScale: Scale.Diatonic,
+      currentShift: 0,
+    };
+
+    for (const element of elements) {
+      if (element.elementType === ElementType.Note) {
+        this.handleNote(element as NoteElement, workspace);
+      } else if (element.elementType === ElementType.ModeKey) {
+        this.handleModeKey(element as ModeKeyElement, workspace);
+      } else if (element.elementType === ElementType.Martyria) {
+        this.handleMartyria(element as MartyriaElement, workspace);
+      } else if (element.elementType === ElementType.Tempo) {
+        this.handleTempo(element as TempoElement, workspace);
+      }
+    }
+
+    this.processGorgons(workspace.nodes, workspace.gorgonIndexes);
+
+    return workspace.nodes;
+  }
+
+  private static handleNote(
+    noteElement: Readonly<NoteElement>,
+    workspace: AnalysisWorkspace,
+  ) {
+    workspace.currentNote += getNeumeValue(noteElement.quantitativeNeume)!;
+    const noteSpread: number[] = getNoteSpread(noteElement.quantitativeNeume);
+    const currentNotes: number[] = noteSpread.map(
+      (x) => workspace.currentNote + x,
+    );
+
+    // Create the note atom nodes for each note atom in the spread, but do not
+    // append them to the node list until we determine how they should be
+    // interleaved with other nodes.
+    const noteAtomNodes = currentNotes.map((x, index) => {
+      const noteAtomNode: NoteAtomNode = new NoteAtomNode();
+      noteAtomNode.elementIndex = noteElement.index;
+      noteAtomNode.physicalNote = getScaleNoteFromValue(x);
+      noteAtomNode.duration = 1;
+      noteAtomNode.ignoreAttractions = noteElement.ignoreAttractions;
+      if (noteElement.timeNeume && index === noteSpread.length - 1) {
+        noteAtomNode.duration += timeMap.get(noteElement.timeNeume)!;
+      }
+      if (noteElement.koronis && index === noteSpread.length - 1) {
+        noteAtomNode.duration *= 2;
+      }
+      if (
+        noteElement.quantitativeNeume === QuantitativeNeume.Hyporoe ||
+        noteElement.quantitativeNeume ===
+          QuantitativeNeume.PetastiPlusHyporoe ||
+        noteElement.quantitativeNeume ===
+          QuantitativeNeume.OligonPlusHyporoePlusKentemata
+      ) {
+        // Sharp applies to the second note of the spread
+        if (
+          noteElement.accidental &&
+          noteElement.accidental.startsWith('Sharp') &&
+          index === 1
+        ) {
+          noteAtomNode.accidental = this.normalizeAccidental(
+            noteElement.accidental,
+          );
+        }
+      } else {
+        // Sharp applies to the first note of the spread
+        if (
+          noteElement.accidental &&
+          noteElement.accidental.startsWith('Sharp') &&
+          index === 0
+        ) {
+          noteAtomNode.accidental = this.normalizeAccidental(
+            noteElement.accidental,
+          );
+        }
+      }
+      // Flat applies to the last note of the spread
+      if (
+        noteElement.accidental &&
+        noteElement.accidental.startsWith('Flat') &&
+        index === currentNotes.length - 1
+      ) {
+        noteAtomNode.accidental = this.normalizeAccidental(
+          noteElement.accidental,
+        );
+      }
+      // Secondary flat applies to the second to last note of the spread
+      if (
+        noteElement.secondaryAccidental &&
+        index === currentNotes.length - 2
+      ) {
+        noteAtomNode.accidental = this.normalizeAccidental(
+          noteElement.secondaryAccidental,
+        );
+      }
+      // Tertiary flat applies to the first note of the spread
+      if (noteElement.tertiaryAccidental && index === 0) {
+        noteAtomNode.accidental = this.normalizeAccidental(
+          noteElement.tertiaryAccidental,
+        );
+      }
+      return noteAtomNode;
+    });
+
+    switch (noteElement.quantitativeNeume) {
+      case QuantitativeNeume.OligonPlusHamiliPlusKentemata:
+      case QuantitativeNeume.OligonPlusIsonPlusKentemata:
+      case QuantitativeNeume.OligonPlusElaphronPlusKentemata:
+      case QuantitativeNeume.OligonPlusApostrophosPlusKentemata:
+      case QuantitativeNeume.OligonPlusElaphronPlusApostrophosPlusKentemata:
+      case QuantitativeNeume.OligonKentimaMiddleKentimata:
+      case QuantitativeNeume.OligonPlusKentemataPlusHypsiliLeft:
+      case QuantitativeNeume.OligonPlusKentemataPlusHypsiliRight:
+      case QuantitativeNeume.OligonPlusKentemata:
+        this.handleKentemataCombo(noteElement, noteAtomNodes, workspace);
+        break;
+      case QuantitativeNeume.KentemataPlusOligon:
+        this.handleKentemataOligon(noteElement, noteAtomNodes, workspace);
+        break;
+      case QuantitativeNeume.Hyporoe:
+      case QuantitativeNeume.PetastiPlusHyporoe:
+        this.handleHyporoe(noteElement, noteAtomNodes, workspace);
+        break;
+      case QuantitativeNeume.DoubleApostrophos:
+      case QuantitativeNeume.IsonPlusApostrophos:
+        this.handleApostrophosCombo(noteElement, noteAtomNodes, workspace);
+        break;
+      case QuantitativeNeume.RunningElaphron:
+      case QuantitativeNeume.PetastiPlusRunningElaphron:
+        this.handleRunningElaphron(noteElement, noteAtomNodes, workspace);
+        break;
+      case QuantitativeNeume.OligonPlusRunningElaphronPlusKentemata:
+        this.handleRunningElaphronKentemata(
+          noteElement,
+          noteAtomNodes,
+          workspace,
+        );
+        break;
+      case QuantitativeNeume.OligonPlusHyporoePlusKentemata:
+        this.handleHyporoeKentemata(noteElement, noteAtomNodes, workspace);
+        break;
+      case QuantitativeNeume.Breath:
+      case QuantitativeNeume.Cross:
+      case QuantitativeNeume.VareiaDotted:
+      case QuantitativeNeume.VareiaDotted2:
+      case QuantitativeNeume.VareiaDotted3:
+      case QuantitativeNeume.VareiaDotted4:
+        this.handleRest(noteElement, workspace);
+        break;
+      default:
+        this.handleDefault(noteElement, noteAtomNodes, workspace);
+        break;
+    }
+  }
+
+  private static handleKentemataCombo(
+    noteElement: Readonly<NoteElement>,
+    noteAtomNodes: NoteAtomNode[],
+    workspace: AnalysisWorkspace,
+  ) {
+    // Note that this function does not contain the following special cases:
+    //   - OligonPlusHyporoePlusKentemata
+    //   - OligonPlusRunningElaphronPlusKentemata
+    //   - KentemataPlusOligon
+    // These are handled separately.
+    if (noteAtomNodes.length !== 2) {
+      throw new Error('Unexpected length: ' + noteAtomNodes.length);
+    }
+
+    // Bottom fthora applies to the first note of the spread
+    if (noteElement.fthora && noteElement.fthora.endsWith('_Bottom')) {
+      this.handleFthora(
+        noteAtomNodes[0].physicalNote,
+        noteElement.fthora,
+        noteElement.chromaticFthoraNote,
+        noteElement.index,
+        workspace,
+      );
+    }
+    // Secondary fthora applies to the first note of the spread
+    if (noteElement.secondaryFthora) {
+      this.handleFthora(
+        noteAtomNodes[0].physicalNote,
+        noteElement.secondaryFthora,
+        noteElement.chromaticFthoraNote,
+        noteElement.index,
+        workspace,
+      );
+    }
+    // Ison applies to the first note of the spread
+    if (noteElement.ison) {
+      const isonNode: IsonNode = new IsonNode();
+      isonNode.elementIndex = noteElement.index;
+      isonNode.ison = noteElement.ison;
+      workspace.nodes.push(isonNode);
+    }
+    // Secondary gorgon applies to the first note of the spread
+    if (noteElement.secondaryGorgonNeume) {
+      const gorgonIndex: GorgonIndex = {
+        neume: noteElement.secondaryGorgonNeume,
+        index: workspace.nodes.length,
+      };
+      workspace.gorgonIndexes.push(gorgonIndex);
+    }
+    this.finalizeNoteAtomNode(noteAtomNodes[0], workspace);
+
+    // Top fthora applies to the second note of the spread
+    if (noteElement.fthora && noteElement.fthora.endsWith('_Top')) {
+      this.handleFthora(
+        noteAtomNodes[1].physicalNote,
+        noteElement.fthora,
+        noteElement.chromaticFthoraNote,
+        noteElement.index,
+        workspace,
+      );
+    }
+    // Gorgon applies to the kentemata
+    if (noteElement.gorgonNeume) {
+      const gorgonIndex: GorgonIndex = {
+        neume: noteElement.gorgonNeume,
+        index: workspace.nodes.length,
+      };
+      workspace.gorgonIndexes.push(gorgonIndex);
+    }
+    this.finalizeNoteAtomNode(noteAtomNodes[1], workspace);
+  }
+
+  private static handleKentemataOligon(
+    noteElement: Readonly<NoteElement>,
+    noteAtomNodes: NoteAtomNode[],
+    workspace: AnalysisWorkspace,
+  ) {
+    if (noteAtomNodes.length !== 2) {
+      throw new Error('Unexpected length: ' + noteAtomNodes.length);
+    }
+
+    // Gorgon applies to the kentemata
+    if (noteElement.gorgonNeume) {
+      const gorgonIndex: GorgonIndex = {
+        neume: noteElement.gorgonNeume,
+        index: workspace.nodes.length,
+      };
+      workspace.gorgonIndexes.push(gorgonIndex);
+    }
+    this.finalizeNoteAtomNode(noteAtomNodes[0], workspace);
+
+    // Fthora applies to the oligon
+    if (noteElement.fthora) {
+      this.handleFthora(
+        noteAtomNodes[1].physicalNote,
+        noteElement.fthora,
+        noteElement.chromaticFthoraNote,
+        noteElement.index,
+        workspace,
+      );
+    }
+    // Ison applies to the oligon
+    if (noteElement.ison) {
+      const isonNode: IsonNode = new IsonNode();
+      isonNode.elementIndex = noteElement.index;
+      isonNode.ison = noteElement.ison;
+      workspace.nodes.push(isonNode);
+    }
+    this.finalizeNoteAtomNode(noteAtomNodes[1], workspace);
+  }
+
+  private static handleHyporoe(
+    noteElement: Readonly<NoteElement>,
+    noteAtomNodes: NoteAtomNode[],
+    workspace: AnalysisWorkspace,
+  ) {
+    if (noteAtomNodes.length !== 2) {
+      throw new Error('Unexpected length: ' + noteAtomNodes.length);
+    }
+
+    // Top fthora applies to the first note of the spread
+    if (noteElement.fthora && noteElement.fthora.endsWith('_Top')) {
+      this.handleFthora(
+        noteAtomNodes[0].physicalNote,
+        noteElement.fthora,
+        noteElement.chromaticFthoraNote,
+        noteElement.index,
+        workspace,
+      );
+    }
+    // Gorgon applies to the first note of the spread
+    if (noteElement.gorgonNeume) {
+      const gorgonIndex: GorgonIndex = {
+        neume: noteElement.gorgonNeume,
+        index: workspace.nodes.length,
+      };
+      workspace.gorgonIndexes.push(gorgonIndex);
+    }
+    this.finalizeNoteAtomNode(noteAtomNodes[0], workspace);
+
+    // Bottom fthora applies to the second note of the spread
+    if (noteElement.fthora && noteElement.fthora.endsWith('_Bottom')) {
+      this.handleFthora(
+        noteAtomNodes[1].physicalNote,
+        noteElement.fthora,
+        noteElement.chromaticFthoraNote,
+        noteElement.index,
+        workspace,
+      );
+    }
+    // Ison applies to the second note of the spread
+    if (noteElement.ison) {
+      const isonNode: IsonNode = new IsonNode();
+      isonNode.elementIndex = noteElement.index;
+      isonNode.ison = noteElement.ison;
+      workspace.nodes.push(isonNode);
+    }
+    this.finalizeNoteAtomNode(noteAtomNodes[1], workspace);
+  }
+
+  private static handleApostrophosCombo(
+    noteElement: Readonly<NoteElement>,
+    noteAtomNodes: NoteAtomNode[],
+    workspace: AnalysisWorkspace,
+  ) {
+    if (noteAtomNodes.length !== 2) {
+      throw new Error('Unexpected length: ' + noteAtomNodes.length);
+    }
+
+    // Fthora applies to the first note of the spread
+    if (noteElement.fthora) {
+      this.handleFthora(
+        noteAtomNodes[0].physicalNote,
+        noteElement.fthora,
+        noteElement.chromaticFthoraNote,
+        noteElement.index,
+        workspace,
+      );
+    }
+    // Ison applies to the first note of the spread
+    if (noteElement.ison) {
+      const isonNode: IsonNode = new IsonNode();
+      isonNode.elementIndex = noteElement.index;
+      isonNode.ison = noteElement.ison;
+      workspace.nodes.push(isonNode);
+    }
+    // Secondary gorgon applies to the first note of the spread
+    if (noteElement.secondaryGorgonNeume) {
+      const gorgonIndex: GorgonIndex = {
+        neume: noteElement.secondaryGorgonNeume,
+        index: workspace.nodes.length,
+      };
+      workspace.gorgonIndexes.push(gorgonIndex);
+    }
+    this.finalizeNoteAtomNode(noteAtomNodes[0], workspace);
+
+    // Gorgon applies to the second note of the spread
+    if (noteElement.gorgonNeume) {
+      const gorgonIndex: GorgonIndex = {
+        neume: noteElement.gorgonNeume,
+        index: workspace.nodes.length,
+      };
+      workspace.gorgonIndexes.push(gorgonIndex);
+    }
+    this.finalizeNoteAtomNode(noteAtomNodes[1], workspace);
+  }
+
+  private static handleRunningElaphron(
+    noteElement: Readonly<NoteElement>,
+    noteAtomNodes: NoteAtomNode[],
+    workspace: AnalysisWorkspace,
+  ) {
+    if (noteAtomNodes.length !== 2) {
+      throw new Error('Unexpected length: ' + noteAtomNodes.length);
+    }
+
+    // Secondary fthora applies to the first note of the spread
+    if (noteElement.secondaryFthora) {
+      this.handleFthora(
+        noteAtomNodes[0].physicalNote,
+        noteElement.secondaryFthora,
+        noteElement.chromaticFthoraNote,
+        noteElement.index,
+        workspace,
+      );
+    }
+    // Add a virtual gorgon to the first note of the spread
+    const gorgonIndex: GorgonIndex = {
+      neume: GorgonNeume.Gorgon_Top,
+      index: workspace.nodes.length,
+    };
+    workspace.gorgonIndexes.push(gorgonIndex);
+    this.finalizeNoteAtomNode(noteAtomNodes[0], workspace);
+
+    // Fthora applies to the second note of the spread
+    if (noteElement.fthora) {
+      this.handleFthora(
+        noteAtomNodes[1].physicalNote,
+        noteElement.fthora,
+        noteElement.chromaticFthoraNote,
+        noteElement.index,
+        workspace,
+      );
+    }
+    // Ison applies to the second note of the spread
+    if (noteElement.ison) {
+      const isonNode: IsonNode = new IsonNode();
+      isonNode.elementIndex = noteElement.index;
+      isonNode.ison = noteElement.ison;
+      workspace.nodes.push(isonNode);
+    }
+    this.finalizeNoteAtomNode(noteAtomNodes[1], workspace);
+  }
+
+  private static handleRunningElaphronKentemata(
+    noteElement: Readonly<NoteElement>,
+    noteAtomNodes: NoteAtomNode[],
+    workspace: AnalysisWorkspace,
+  ) {
+    if (noteAtomNodes.length !== 3) {
+      throw new Error('Unexpected length: ' + noteAtomNodes.length);
+    }
+
+    // Tertiary fthora applies to the first note of the spread
+    if (noteElement.tertiaryFthora) {
+      this.handleFthora(
+        noteAtomNodes[0].physicalNote,
+        noteElement.tertiaryFthora,
+        noteElement.chromaticFthoraNote,
+        noteElement.index,
+        workspace,
+      );
+    }
+    // Add a virtual gorgon to the first note of the spread
+    const gorgonIndex: GorgonIndex = {
+      neume: GorgonNeume.Gorgon_Top,
+      index: workspace.nodes.length,
+    };
+    workspace.gorgonIndexes.push(gorgonIndex);
+    this.finalizeNoteAtomNode(noteAtomNodes[0], workspace);
+
+    // Secondary fthora applies to the second note of the spread
+    if (noteElement.secondaryFthora) {
+      this.handleFthora(
+        noteAtomNodes[1].physicalNote,
+        noteElement.secondaryFthora,
+        noteElement.chromaticFthoraNote,
+        noteElement.index,
+        workspace,
+      );
+    }
+    // Ison applies to the second note of the spread
+    if (noteElement.ison) {
+      const isonNode: IsonNode = new IsonNode();
+      isonNode.elementIndex = noteElement.index;
+      isonNode.ison = noteElement.ison;
+      workspace.nodes.push(isonNode);
+    }
+    this.finalizeNoteAtomNode(noteAtomNodes[1], workspace);
+
+    // Fthora applies to the third note of the spread
+    if (noteElement.fthora) {
+      this.handleFthora(
+        noteAtomNodes[2].physicalNote,
+        noteElement.fthora,
+        noteElement.chromaticFthoraNote,
+        noteElement.index,
+        workspace,
+      );
+    }
+    // Gorgon applies to the third note of the spread
+    if (noteElement.gorgonNeume) {
+      const gorgonIndex: GorgonIndex = {
+        neume: noteElement.gorgonNeume,
+        index: workspace.nodes.length,
+      };
+      workspace.gorgonIndexes.push(gorgonIndex);
+    }
+    this.finalizeNoteAtomNode(noteAtomNodes[2], workspace);
+  }
+
+  private static handleHyporoeKentemata(
+    noteElement: Readonly<NoteElement>,
+    noteAtomNodes: NoteAtomNode[],
+    workspace: AnalysisWorkspace,
+  ) {
+    if (noteAtomNodes.length !== 3) {
+      throw new Error('Unexpected length: ' + noteAtomNodes.length);
+    }
+
+    // Secondary fthora applies to the first note of the spread
+    if (noteElement.secondaryFthora) {
+      this.handleFthora(
+        noteAtomNodes[0].physicalNote,
+        noteElement.secondaryFthora,
+        noteElement.chromaticFthoraNote,
+        noteElement.index,
+        workspace,
+      );
+    }
+    // Secondary gorgon applies to the first note of the spread
+    if (noteElement.secondaryGorgonNeume) {
+      const gorgonIndex: GorgonIndex = {
+        neume: noteElement.secondaryGorgonNeume,
+        index: workspace.nodes.length,
+      };
+      workspace.gorgonIndexes.push(gorgonIndex);
+    }
+    this.finalizeNoteAtomNode(noteAtomNodes[0], workspace);
+
+    this.finalizeNoteAtomNode(noteAtomNodes[1], workspace);
+    // Ison applies to the second note of the spread
+    if (noteElement.ison) {
+      const isonNode: IsonNode = new IsonNode();
+      isonNode.elementIndex = noteElement.index;
+      isonNode.ison = noteElement.ison;
+      workspace.nodes.push(isonNode);
+    }
+
+    // Fthora applies to the third note of the spread
+    if (noteElement.fthora) {
+      this.handleFthora(
+        noteAtomNodes[2].physicalNote,
+        noteElement.fthora,
+        noteElement.chromaticFthoraNote,
+        noteElement.index,
+        workspace,
+      );
+    }
+    // Gorgon applies to the third note of the spread
+    if (noteElement.gorgonNeume) {
+      const gorgonIndex: GorgonIndex = {
+        neume: noteElement.gorgonNeume,
+        index: workspace.nodes.length,
+      };
+      workspace.gorgonIndexes.push(gorgonIndex);
+    }
+    this.finalizeNoteAtomNode(noteAtomNodes[2], workspace);
+  }
+
+  private static handleDefault(
+    noteElement: Readonly<NoteElement>,
+    noteAtomNodes: NoteAtomNode[],
+    workspace: AnalysisWorkspace,
+  ) {
+    if (noteAtomNodes.length !== 1) {
+      throw new Error('Unexpected length: ' + noteAtomNodes.length);
+    }
+
+    if (noteElement.fthora) {
+      this.handleFthora(
+        noteAtomNodes[0].physicalNote,
+        noteElement.fthora,
+        noteElement.chromaticFthoraNote,
+        noteElement.index,
+        workspace,
+      );
+    }
+    if (noteElement.ison) {
+      const isonNode: IsonNode = new IsonNode();
+      isonNode.elementIndex = noteElement.index;
+      isonNode.ison = noteElement.ison;
+      workspace.nodes.push(isonNode);
+    }
+    if (noteElement.gorgonNeume) {
+      const gorgonIndex: GorgonIndex = {
+        neume: noteElement.gorgonNeume,
+        index: workspace.nodes.length,
+      };
+      workspace.gorgonIndexes.push(gorgonIndex);
+    }
+    this.finalizeNoteAtomNode(noteAtomNodes[0], workspace);
+  }
+
+  private static finalizeNoteAtomNode(
+    noteAtomNode: NoteAtomNode,
+    workspace: AnalysisWorkspace,
+  ) {
+    noteAtomNode.virtualNote = getScaleNoteFromValue(
+      getScaleNoteValue(noteAtomNode.physicalNote) + workspace.currentShift,
+    );
+    noteAtomNode.scale = workspace.currentScale;
+    workspace.nodes.push(noteAtomNode);
+  }
+
+  private static handleRest(
+    noteElement: Readonly<NoteElement>,
+    workspace: AnalysisWorkspace,
+  ) {
+    const restNode: RestNode = new RestNode();
+    restNode.elementIndex = noteElement.index;
+    restNode.duration = restMap.get(noteElement.quantitativeNeume)!;
+    workspace.nodes.push(restNode);
+  }
+
+  private static handleModeKey(
+    modeKeyElement: Readonly<ModeKeyElement>,
+    workspace: AnalysisWorkspace,
+  ) {
+    // Reset workspace flags
+    workspace.currentNote = getScaleNoteValue(modeKeyElement.scaleNote);
+    workspace.currentScale = modeKeyElement.scale;
+    workspace.currentShift = 0;
+
+    const modeKeyNode: ModeKeyNode = new ModeKeyNode();
+    modeKeyNode.elementIndex = modeKeyElement.index;
+    modeKeyNode.physicalNote = getScaleNoteFromValue(workspace.currentNote);
+    modeKeyNode.virtualNote = getScaleNoteFromValue(
+      workspace.currentNote + workspace.currentShift,
+    );
+    modeKeyNode.scale = workspace.currentScale;
+    modeKeyNode.ignoreAttractions = modeKeyElement.ignoreAttractions;
+    modeKeyNode.permanentEnharmonicZo = modeKeyElement.permanentEnharmonicZo;
+    if (
+      modeKeyElement.mode === 4 &&
+      modeKeyElement.scale === Scale.Diatonic &&
+      (modeKeyElement.scaleNote === ScaleNote.Pa ||
+        modeKeyElement.scaleNote === ScaleNote.Vou)
+    ) {
+      modeKeyNode.legetos = true;
+    }
+    workspace.nodes.push(modeKeyNode);
+
+    if (modeKeyElement.fthora) {
+      this.handleFthora(
+        modeKeyNode.physicalNote,
+        modeKeyElement.fthora,
+        null,
+        modeKeyElement.index,
+        workspace,
+      );
+    }
+
+    const tempoNode: TempoNode = new TempoNode();
+    tempoNode.elementIndex = modeKeyElement.index;
+    tempoNode.bpm = modeKeyElement.bpm ?? 120;
+    workspace.nodes.push(tempoNode);
+  }
+
+  private static handleFthora(
+    physicalNote: ScaleNote,
+    fthora: Fthora,
+    chromaticFthoraNote: ScaleNote | null,
+    index: number,
+    workspace: AnalysisWorkspace,
+  ) {
+    workspace.currentScale =
+      LayoutService.getScaleFromFthora(
+        fthora,
+        getScaleNoteValue(physicalNote),
+      ) || workspace.currentScale;
+    // General flat/sharp implies a switch to the diatonic scale
+    if (fthora.startsWith('GeneralFlat') || fthora.startsWith('GeneralSharp')) {
+      workspace.currentScale = Scale.Diatonic;
+    }
+
+    workspace.currentShift = LayoutService.getShift(
+      getScaleNoteValue(physicalNote),
+      workspace.currentScale,
+      fthora,
+      chromaticFthoraNote,
+    );
+
+    const fthoraNode: FthoraNode = new FthoraNode();
+    fthoraNode.elementIndex = index;
+    fthoraNode.physicalNote = physicalNote;
+    fthoraNode.virtualNote = getScaleNoteFromValue(
+      getScaleNoteValue(physicalNote) + workspace.currentShift,
+    );
+    fthoraNode.scale = workspace.currentScale;
+    fthoraNode.generalFlat = fthora.startsWith('GeneralFlat');
+    fthoraNode.generalSharp = fthora.startsWith('GeneralSharp');
+    workspace.nodes.push(fthoraNode);
+  }
+
+  private static handleMartyria(
+    martyriaElement: Readonly<MartyriaElement>,
+    workspace: AnalysisWorkspace,
+  ) {
+    if (!martyriaElement.auto) {
+      workspace.currentNote = getNoteValue(martyriaElement.note);
+      workspace.currentScale = martyriaElement.scale;
+      workspace.currentShift = 0;
+    }
+
+    if (martyriaElement.fthora) {
+      this.handleFthora(
+        getScaleNoteFromValue(workspace.currentNote),
+        martyriaElement.fthora,
+        null,
+        martyriaElement.index,
+        workspace,
+      );
+    }
+
+    if (martyriaElement.tempo) {
+      const tempoNode: TempoNode = new TempoNode();
+      tempoNode.elementIndex = martyriaElement.index;
+      tempoNode.bpm =
+        martyriaElement.bpm || tempoToBpmMap.get(martyriaElement.tempo)!;
+      workspace.nodes.push(tempoNode);
+    }
+  }
+
+  private static handleTempo(
+    tempoElement: Readonly<TempoElement>,
+    workspace: AnalysisWorkspace,
+  ) {
+    const tempoNode: TempoNode = new TempoNode();
+    tempoNode.elementIndex = tempoElement.index;
+    tempoNode.bpm = tempoElement.bpm || tempoToBpmMap.get(tempoElement.neume)!;
+    workspace.nodes.push(tempoNode);
+  }
+
+  private static processGorgons(
+    nodes: AnalysisNode[],
+    gorgonIndexes: GorgonIndex[],
+  ) {
+    for (const gorgon of gorgonIndexes) {
+      if (gorgon.index < 0) {
+        throw new Error('Gorgon index must be positive: ' + gorgon.index);
+      }
+      const durations = gorgonMap.get(gorgon.neume)!.slice();
+      let cur = gorgon.index - 1;
+
+      // Rewind until we reach the first temporal node or the head node.
+      while (
+        cur > -1 &&
+        nodes[cur].nodeType !== NodeType.NoteAtomNode &&
+        nodes[cur].nodeType !== NodeType.RestNode
+      ) {
+        cur -= 1;
+      }
+
+      // If the piece starts with a gorgon, skip the first duration.
+      if (cur === -1) {
+        durations.shift();
+        cur += 1;
+      }
+
+      for (let i = 0; i < durations.length; i++) {
+        // Advance until we reach the next temporal node.
+        while (
+          nodes[cur].nodeType !== NodeType.NoteAtomNode &&
+          nodes[cur].nodeType !== NodeType.RestNode
+        ) {
+          cur += 1;
+        }
+
+        // Apply the gorgon.
+        const affectedNode = nodes[cur] as TemporalNode;
+        affectedNode.duration -= durations[i];
+        cur += 1;
+      }
+    }
+  }
+
+  private static normalizeAccidental(accidental: Accidental): Accidental {
+    switch (accidental) {
+      case Accidental.Flat_2_RightSecondary:
+      case Accidental.Flat_2_RightTertiary:
+        return Accidental.Flat_2_Right;
+      case Accidental.Flat_4_RightSecondary:
+      case Accidental.Flat_4_RightTertiary:
+        return Accidental.Flat_4_Right;
+      case Accidental.Flat_6_RightSecondary:
+      case Accidental.Flat_6_RightTertiary:
+        return Accidental.Flat_6_Right;
+      case Accidental.Flat_8_RightSecondary:
+      case Accidental.Flat_8_RightTertiary:
+        return Accidental.Flat_8_Right;
+      default:
+        return accidental;
+    }
+  }
+}
+
+const timeMap = new Map<TimeNeume, number>([
+  [TimeNeume.Klasma_Bottom, 1],
+  [TimeNeume.Klasma_Top, 1],
+  [TimeNeume.Hapli, 1],
+  [TimeNeume.Dipli, 2],
+  [TimeNeume.Tripli, 3],
+  [TimeNeume.Tetrapli, 4],
+]);
+
+const restMap = new Map<QuantitativeNeume, number>([
+  [QuantitativeNeume.Breath, 0],
+  [QuantitativeNeume.Cross, 0],
+  [QuantitativeNeume.VareiaDotted, 1],
+  [QuantitativeNeume.VareiaDotted2, 2],
+  [QuantitativeNeume.VareiaDotted3, 3],
+  [QuantitativeNeume.VareiaDotted4, 4],
+]);
+
+const gorgonMap = new Map<GorgonNeume, number[]>([
+  [GorgonNeume.Gorgon_Top, [0.5, 0.5]],
+  [GorgonNeume.Gorgon_Bottom, [0.5, 0.5]],
+  [GorgonNeume.GorgonDottedLeft, [1 / 3, 2 / 3]],
+  [GorgonNeume.GorgonDottedRight, [2 / 3, 1 / 3]],
+  [GorgonNeume.Digorgon, [2 / 3, 2 / 3, 2 / 3]],
+  [GorgonNeume.DigorgonDottedLeft1, [0.5, 0.75, 0.75]],
+  [GorgonNeume.DigorgonDottedLeft2, [0.75, 0.5, 0.75]],
+  [GorgonNeume.DigorgonDottedRight, [0.75, 0.75, 0.5]],
+  [GorgonNeume.Trigorgon, [0.75, 0.75, 0.75, 0.75]],
+  // TODO handle trigorgon dotted
+  [GorgonNeume.TrigorgonDottedLeft1, [0.75, 0.75, 0.75, 0.75]],
+  [GorgonNeume.TrigorgonDottedLeft2, [0.75, 0.75, 0.75, 0.75]],
+  [GorgonNeume.TrigorgonDottedRight, [0.75, 0.75, 0.75, 0.75]],
+  // Secondary
+  [GorgonNeume.GorgonSecondary, [0.5, 0.5]],
+  [GorgonNeume.GorgonDottedLeftSecondary, [1 / 3, 2 / 3]],
+  [GorgonNeume.GorgonDottedRightSecondary, [2 / 3, 1 / 3]],
+  [GorgonNeume.DigorgonSecondary, [2 / 3, 2 / 3, 2 / 3]],
+  [GorgonNeume.DigorgonDottedLeft1Secondary, [0.5, 0.75, 0.75]],
+  [GorgonNeume.DigorgonDottedRightSecondary, [0.75, 0.75, 0.5]],
+  [GorgonNeume.TrigorgonSecondary, [0.75, 0.75, 0.75, 0.75]],
+  // TODO handle trigorgon dotted
+  [GorgonNeume.TrigorgonDottedLeft1Secondary, [0.75, 0.75, 0.75, 0.75]],
+  [GorgonNeume.TrigorgonDottedRightSecondary, [0.75, 0.75, 0.75, 0.75]],
+
+  [GorgonNeume.Argon, [0.5, 0.5, -1]],
+  [GorgonNeume.Hemiolion, [0.5, 0.5, -2]],
+  [GorgonNeume.Diargon, [0.5, 0.5, -3]],
+]);
+
+const tempoToBpmMap = new Map<TempoSign, number>([
+  [TempoSign.VerySlow, 40], // < 56 triargon?
+  [TempoSign.Slower, 56], // 56 - 80 diargon
+  [TempoSign.Slow, 80], // 80 - 100 hemiolion
+  [TempoSign.Moderate, 100], // 100 - 168 argon
+  [TempoSign.Medium, 130], // 130 argon + gorgon
+  [TempoSign.Quick, 168], // 168 - 208 gorgon
+  [TempoSign.Quicker, 208], // 208+ digorgon
+  [TempoSign.VeryQuick, 250], // unattested? trigorgon
+
+  [TempoSign.VerySlowAbove, 40], // < 56 triargon?
+  [TempoSign.SlowerAbove, 56], // 56 - 80 diargon
+  [TempoSign.SlowAbove, 80], // 80 - 100 hemiolion
+  [TempoSign.ModerateAbove, 100], // 100 - 168 argon
+  [TempoSign.MediumAbove, 130], // 130 argon + gorgon
+  [TempoSign.QuickAbove, 168], // 168 - 208 gorgon
+  [TempoSign.QuickerAbove, 208], // 208+ digorgon
+  [TempoSign.VeryQuickAbove, 250], // unattested? trigorgon
+]);

--- a/src/services/audio/PlaybackService.test.ts
+++ b/src/services/audio/PlaybackService.test.ts
@@ -99,52 +99,7 @@ describe('PlaybackService', () => {
     });
   });
 
-  describe('applyModeKey', () => {
-    it('should clear enharmonic Ga', () => {
-      const service = new PlaybackService();
-
-      const workspace = getDefaultWorkspace([], service.diatonicScale);
-
-      workspace.enharmonicGa = true;
-
-      service.applyModeKey(
-        getModeKey(1, Scale.Diatonic, ScaleNote.Pa),
-        workspace,
-      );
-
-      expect(workspace.enharmonicGa).toBeFalsy();
-    });
-
-    it('should clear enharmonic Zo', () => {
-      const service = new PlaybackService();
-
-      const workspace = getDefaultWorkspace([], service.diatonicScale);
-
-      workspace.enharmonicZo = true;
-
-      service.applyModeKey(
-        getModeKey(1, Scale.Diatonic, ScaleNote.Pa),
-        workspace,
-      );
-
-      expect(workspace.enharmonicZo).toBeFalsy();
-    });
-
-    it('should clear enharmonic Vou', () => {
-      const service = new PlaybackService();
-
-      const workspace = getDefaultWorkspace([], service.diatonicScale);
-
-      workspace.enharmonicVou = true;
-
-      service.applyModeKey(
-        getModeKey(1, Scale.Diatonic, ScaleNote.Pa),
-        workspace,
-      );
-
-      expect(workspace.enharmonicVou).toBeFalsy();
-    });
-
+  describe('handleModeKey', () => {
     it('should clear general flat', () => {
       const service = new PlaybackService();
 
@@ -152,7 +107,7 @@ describe('PlaybackService', () => {
 
       workspace.generalFlat = true;
 
-      service.applyModeKey(
+      service.handleModeKey(
         getModeKey(1, Scale.Diatonic, ScaleNote.Pa),
         workspace,
       );
@@ -167,7 +122,7 @@ describe('PlaybackService', () => {
 
       workspace.generalSharp = true;
 
-      service.applyModeKey(
+      service.handleModeKey(
         getModeKey(1, Scale.Diatonic, ScaleNote.Pa),
         workspace,
       );


### PR DESCRIPTION
This PR is a significant revision of the playback subsystem. While I had originally intended to refactor the portions of the layout service and the playback service that interpret neumes into a separate analysis service, this didn't turn out as well as I had hoped in practice due to the largely different concerns of layout versus playback. So instead I kept the core idea, which is that playback is easier to debug if neumes are first pre-processed into an intermediate representation. Therefore, I wrote a new analysis service specifically for playback, which transforms the neumes into an intermediate representation. The playback service now deals exclusively with this intermediate representation. I was able to reuse the `getScaleFromFthora` and `getShift` functions from the layout service (now `public` for use in the analysis service), with some minor modifications; however, the ugly `getSpreadIndex` function is still unique to the layout service (its logic is now duplicated in the analysis service) and the concept of valid fthores and fthora restrictions is still exclusively the domain of the layout service.

The biggest improvements to playback are around compound neume spreads. The analysis service is now completely aware of these and breaks them down into note atoms. Fthores, ison markings, and accidentals are applied to the correct note atom in the spread. The "chromatic fthora note" for enharmonic fthores was only used by the playback service for disambiguation purposes, and now there is no ambiguity; therefore, I am removing this concept from the GUI: "chromatic fthora notes" now are exclusively for chromatic fthores.

The idea behind the intermediate representation is that it should be a complete higher-level representation of note durations and pitches. For pitches, this representation consists of a physical note, virtual note (which may be the same as the physical note if no fthora is in effect, or if the fthora happens to match the physical note), and a scale. For durations, this consists of an integer. In addition to note atoms, pitches can be present in mode keys and fthores. These are plumbed through as unique events. Ison and tempo changes are plumbed through as simple events. This all has the effect of normalizing the various complex representations of these abstract concepts into a flat representation that is easy to debug. The first step when examining a playback issue is to examining this intermediate representation and ensure that it makes sense. For example, limitations in the underlying object model such as #318 will show up as problems in the intermediate representation, and it is easy to identify these issues before the playback service begins executing the intermediate representation.

Once the intermediate representation is calculated, it is passed into the playback service for execution. The playback service is a lot easier to read, since it doesn't have logic for interpreting neumes. Two main improvements have been made here: first, frequencies are now calculated based on absolute pitch rather than relative pitch. This approach fixes a number of issues in Makarios Anhr and my Axion Estins, but it is not without its challenges (see below). The logic for enharmonic scale changes has also been significantly simplified. Enharmonic fthores used to terminate at the next martyria, which is incorrect; they are now treated just like any other fthora. I don't attempt to deal with the general fthora termination problems that currently exist in the software in this PR, but that would be the next logical step after this PR. I've also removed the concept of permanent enharmonic Vou: this seems like unnecessary complexity and was never exposed in the UI. In any case, this should not be an issue for any properly notated score and is not a problem for my Axion Estins, which definitely stress test the scale capabilities of the software.

I have played back all my Axion Estins with this PR, and while a handful of them got worse (due to the single remaining major issue described below), almost all of them played back much better than before. Some previously unplayable ones became playable for the first time. And this process has proved invaluable for me as I copyedit the work for final publication, as there are many minor editorial issues that I would not have noticed had it not been for playing them back with (functioning) software. Unfortunately, one major issue still remains, which is why this PR is still in draft state. Recall that when a fthora is encountered, instead of using `moveDistance` and moving relatively based on the current scale, we are now instead jumping to the absolute frequency, calculated based on Di and the target scale determined by the fthora. This works well overall, but there are a few issues:

- For Spathi, calculating the interval based on Di and the target scale determined by the fthora doesn't work because Di isn't stable relative to the Di frequency configured in the playback options. I've hacked around this by special-casing Spathi and doing the calculation relative to Ga or Ke, then incrementing or decrementing by 12 moria to adjust the result to be relative to be Di. I'm open to better solutions here, but this is working pretty well in practice for my two Axion Estins in Hisâr-Bûselik.
- When a fthora is in effect, you need to adjust the result by the number of moria of the transposition (what is called the "shift" in some parts of the code). Computing this isn't trivial. You can't take the number of moria from the physical note to the virtual (transposed) note in the old scale, because that doesn't work when jumping from diatonic Pa to enharmonic Zo. You can't take the number of moria from the physical note to the virtual note in the new scale either, because that doesn't work in other situations. The compromise I settled on, which works a lot of the time, is to compute the distance from the physical note to Di in the old scale, then compute the distance from Di to the virtual note in the new scale, then sum the two. This works whenever the two scales are aligned on Di; however...
- The above solution breaks down if, say, you are in diatonic Ni and put a hard chromatic fthora on Ni or Vou, thus creating a tonal upheaval. The same occurs in the Anoixantaria by Koukouzelis (abbreviated by Chourmouzios) and the end of To tritto tis erotiseos. In these cases, computing the moria of the transposition as described above breaks down, because the original scale and the target scale aren't aligned on Di. As a result the computation is off by an arbitrary amount since the scales don't align with each other, at least not at the point the algorithm is expecting them to. Conceptually, the scales do align, but just not on Di in both scales: in the case of a hard chromatic fthora on diatonic Vou, they align based on physical Zo/virtual Ke, which is intuitive to me as a human but not to the computer. I can't figure out a heuristic to determine this in code.

I will keep thinking about the above problem and trying to come up with a code heuristic for determining the alignment point; however, if a solution cannot be found, we may need frontend support for choosing the alignment point if we want to go this route.

### Testing done

As mentioned above, I have been doing (and continue to do) copious amounts of manual testing with my forthcoming book of over five dozen Axion Estins, many of which are written in nontraditional scales and serve as a good stress test for the scale and playback capabilities of the software. The only regression I am aware of is the tonal upheaval issue mentioned above.