### PR TITLE
Upgrade `npm` from 9.5.1 to 9.8.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -80,5 +80,5 @@
     "vue-tsc": "^1.8.15"
   },
   "license": "GPL-3.0",
-  "packageManager": "npm@9.5.1"
+  "packageManager": "npm@9.8.1"
 }


### PR DESCRIPTION
This is the version shipped by the latest LTS release of Node, so it seems safe. Tested by running `npm install` locally twice in a row without observing any errors or changes to the lock file.