### PR TITLE
Improve consistency of mode keys

### DIFF
--- a/src/models/ModeKeys.ts
+++ b/src/models/ModeKeys.ts
@@ -266,6 +266,7 @@ export const modeKeyTemplates: ModeKeyTemplate[] = [
     scaleNote: ScaleNote.Ke,
     description: 'Spathi',
     martyria: ModeSign.Alpha,
+    note: ModeSign.Pa,
     quantitativeNeumeRight: QuantitativeNeume.OligonPlusHypsiliRight,
     fthoraAboveQuantitativeNeumeRight: Fthora.Spathi_Bottom,
   },
@@ -319,6 +320,8 @@ export const modeKeyTemplates: ModeKeyTemplate[] = [
     scaleNote: ScaleNote.PaHigh,
     description: 'Heptaphonic (Maqam Hijaz Kar)',
     martyria: ModeSign.SoftChromatic6,
+    note: ModeSign.Pa,
+    fthoraAboveNote: Fthora.HardChromaticPa_Top,
     quantitativeNeumeRight:
       QuantitativeNeume.OligonPlusHypsiliPlusKentimaVertical,
     fthoraAboveQuantitativeNeumeRight: Fthora.HardChromaticThi_Top,


### PR DESCRIPTION
Improve the consistency of the Pl 1st and Pl 2nd mode keys by adding Pa notes wherever they were missing. This is consistent with the other mode keys for these modes and most of the Greek scores I have seen in these two particular maqams (Hisar-Buselik and Hijaz-Kar).