### PR TITLE
Add Pentaphonic Plagal First Mode Key

### DIFF
--- a/src/models/ModeKeys.ts
+++ b/src/models/ModeKeys.ts
@@ -270,6 +270,18 @@ export const modeKeyTemplates: ModeKeyTemplate[] = [
     fthoraAboveQuantitativeNeumeRight: Fthora.Spathi_Bottom,
   },
   {
+    id: 503,
+    mode: 5,
+    scale: Scale.Diatonic,
+    scaleNote: ScaleNote.ZoHigh,
+    fthora: Fthora.Enharmonic_Top,
+    description: 'Pentaphonic',
+    martyria: ModeSign.Alpha,
+    note: ModeSign.Pa,
+    quantitativeNeumeRight: QuantitativeNeume.OligonPlusHypsiliLeft,
+    fthoraAboveQuantitativeNeumeRight: Fthora.Enharmonic_Top,
+  },
+  {
     id: 600,
     mode: 6,
     scale: Scale.HardChromatic,


### PR DESCRIPTION
Add a mode key for Pentaphonic Plagal First Mode (aka Maqam Ajam). This is the most common form I've seen for notating this mode throughout my research of various Axion Estins composed in this style.