### PR TITLE
Add Heptaphonic Plagal Fourth Mode Key

### DIFF
--- a/src/models/ModeKeys.ts
+++ b/src/models/ModeKeys.ts
@@ -382,4 +382,15 @@ export const modeKeyTemplates: ModeKeyTemplate[] = [
     note: ModeSign.Ni,
     quantitativeNeumeRight: QuantitativeNeume.KentemataPlusOligon,
   },
+  {
+    id: 803,
+    mode: 8,
+    scale: Scale.Diatonic,
+    scaleNote: ScaleNote.NiHigh,
+    description: 'Heptaphonic',
+    martyria: ModeSign.Delta,
+    note: ModeSign.Ni,
+    quantitativeNeumeRight:
+      QuantitativeNeume.OligonPlusHypsiliPlusKentimaVertical,
+  },
 ];


### PR DESCRIPTION
Add a mode key for Heptaphonic Plagal Fourth Mode (aka Maqam Mahur). Examples:

- [Papanikolaou](https://www.youtube.com/watch?v=_QK_Ud2DOxw)
- [Arvanitis](https://analogion.com/forum/index.php?threads/%CE%99-%CE%91%CF%81%CE%B2%CE%B1%CE%BD%CE%AF%CF%84%CE%B7%CF%82-3-%CE%86%CE%BE%CE%B9%CE%BF%CE%BD-%CE%95%CF%83%CF%84%CE%AF-%CF%80%CE%BB-%CE%B4%CE%847%CF%86%CF%89%CE%BD%CE%BF%CF%82-%CF%80%CE%BB-%CE%92-%CE%BC%CE%B5-%CE%B1%CE%B3%CE%B9%CE%B1-%CE%B2%CE%B1%CF%81%CF%8D%CF%82-7%CF%86%CF%89%CE%BD%CE%BF%CF%82.8878/)