### PR TITLE
Support Chrysanthine accidentals

### DIFF
--- a/src/components/Editor.vue
+++ b/src/components/Editor.vue
@@ -993,6 +993,8 @@ export default class Editor extends Vue {
     volumeIson: -4,
     volumeMelody: 0,
 
+    alterationMultipliers: [0.5, 0.25, 0.75],
+
     alterationMoriaMap: {
       [Accidental.Flat_2_Right]: -2,
       [Accidental.Flat_4_Right]: -4,
@@ -4856,6 +4858,7 @@ export default class Editor extends Vue {
         this.playbackEvents = this.playbackService.computePlaybackSequence(
           this.elements,
           this.audioOptions,
+          this.score.pageSetup.chrysanthineAccidentals,
         );
 
         if (this.playbackEvents.length === 0) {

--- a/src/components/PageSetupDialog.vue
+++ b/src/components/PageSetupDialog.vue
@@ -279,6 +279,17 @@
 
           <div class="form-group">
             <input
+              id="page-setup-dialog-chrysanthine-accidentals"
+              type="checkbox"
+              v-model="form.chrysanthineAccidentals"
+            />
+            <label for="page-setup-dialog-chrysanthine-accidentals"
+              >Use Chrysanthine Accidentals</label
+            >
+          </div>
+
+          <div class="form-group">
+            <input
               id="page-setup-dialog-no-fthora-restrictions"
               type="checkbox"
               v-model="form.noFthoraRestrictions"

--- a/src/components/PlaybackSettingsDialog.vue
+++ b/src/components/PlaybackSettingsDialog.vue
@@ -377,6 +377,66 @@
         </div>
 
         <div class="form-group row">
+          <span class="alteration-name">Imitonios</span>
+          <div class="row">
+            <input
+              type="number"
+              class="interval"
+              min="0"
+              max="1"
+              step="0.05"
+              :value="options.alterationMultipliers[0]"
+              @change="
+                onAlterationMultiplierChanged(
+                  0,
+                  Number(($event.target as HTMLInputElement).value),
+                )
+              "
+            />
+          </div>
+          <span class="interval-label">&#215;</span>
+        </div>
+        <div class="form-group row">
+          <span class="alteration-name">Enos Tetartimoriou</span>
+          <div class="row">
+            <input
+              type="number"
+              class="interval"
+              min="0"
+              max="1"
+              step="0.05"
+              :value="options.alterationMultipliers[1]"
+              @change="
+                onAlterationMultiplierChanged(
+                  1,
+                  Number(($event.target as HTMLInputElement).value),
+                )
+              "
+            />
+          </div>
+          <span class="interval-label">&#215;</span>
+        </div>
+        <div class="form-group row">
+          <span class="alteration-name">Trion Tetartimoriou</span>
+          <div class="row">
+            <input
+              type="number"
+              class="interval"
+              min="0"
+              max="1"
+              step="0.05"
+              :value="options.alterationMultipliers[2]"
+              @change="
+                onAlterationMultiplierChanged(
+                  2,
+                  Number(($event.target as HTMLInputElement).value),
+                )
+              "
+            />
+          </div>
+          <span class="interval-label">&#215;</span>
+        </div>
+        <div class="form-group row">
           <span class="alteration-name">Diesis Apli</span>
           <div class="row">
             <input
@@ -656,6 +716,8 @@ export default class PlaybackSettingsDialog extends Vue {
     this.options.generalFlatMoria = -6;
     this.options.generalSharpMoria = 4;
 
+    this.options.alterationMultipliers = [0.5, 0.25, 0.75];
+
     this.options.alterationMoriaMap = {
       [Accidental.Flat_2_Right]: -2,
       [Accidental.Flat_4_Right]: -4,
@@ -731,6 +793,15 @@ export default class PlaybackSettingsDialog extends Vue {
     this.options.frequencyDi = +(
       FREQUENCY_G3 * Math.pow(2, this.tuning / 1200)
     ).toFixed(1);
+
+    this.$forceUpdate();
+  }
+
+  onAlterationMultiplierChanged(index: number, multiplier: number) {
+    multiplier = Math.max(0, multiplier);
+    multiplier = Math.min(1, multiplier);
+
+    this.options.alterationMultipliers[index] = multiplier;
 
     this.$forceUpdate();
   }

--- a/src/models/PageSetup.ts
+++ b/src/models/PageSetup.ts
@@ -123,6 +123,7 @@ export class PageSetup {
 
   public hyphenSpacing: number = Unit.fromInch(0.75);
 
+  public chrysanthineAccidentals: boolean = true;
   public noFthoraRestrictions: boolean = false;
 
   public get innerPageWidth() {

--- a/src/models/save/v1/PageSetup.ts
+++ b/src/models/save/v1/PageSetup.ts
@@ -79,5 +79,6 @@ export class PageSetup {
 
   public hyphenSpacing: number = Unit.fromInch(0.75);
 
+  public chrysanthineAccidentals: boolean | undefined = undefined;
   public noFthoraRestrictions: boolean | undefined = undefined;
 }

--- a/src/services/SaveService.ts
+++ b/src/services/SaveService.ts
@@ -215,6 +215,7 @@ export class SaveService {
 
     pageSetup.hyphenSpacing = p.hyphenSpacing;
 
+    pageSetup.chrysanthineAccidentals = p.chrysanthineAccidentals;
     pageSetup.noFthoraRestrictions = p.noFthoraRestrictions || undefined;
   }
 
@@ -690,6 +691,9 @@ export class SaveService {
 
     pageSetup.hyphenSpacing = p.hyphenSpacing;
 
+    pageSetup.chrysanthineAccidentals =
+      p.chrysanthineAccidentals === true ||
+      p.chrysanthineAccidentals === undefined;
     pageSetup.noFthoraRestrictions = p.noFthoraRestrictions === true;
 
     // Fix pageWidth and pageHeight

--- a/src/services/audio/PlaybackService.test.ts
+++ b/src/services/audio/PlaybackService.test.ts
@@ -165,7 +165,7 @@ describe('PlaybackService', () => {
         elements.push(getModeKey(1, Scale.Diatonic, scaleNote));
         elements.push(getNote(QuantitativeNeume.Ison));
 
-        const events = service.computePlaybackSequence(elements, options);
+        const events = service.computePlaybackSequence(elements, options, true);
 
         expect(events[0].frequency).toBeCloseTo(expectedFrequency, 2);
       },
@@ -199,7 +199,7 @@ describe('PlaybackService', () => {
       elements.push(getNote(QuantitativeNeume.Oligon));
       elements.push(getNote(QuantitativeNeume.Oligon));
 
-      const events = service.computePlaybackSequence(elements, options);
+      const events = service.computePlaybackSequence(elements, options, true);
       const expectedFrequencies = [
         80.84, 87.31, 98, 110, 121.12, 130.81, 146.83, 161.67, 174.62, 196, 220,
         242.24, 261.63, 293.67, 323.35, 349.23, 392, 440.01,
@@ -229,7 +229,7 @@ describe('PlaybackService', () => {
         elements.push(getModeKey(4, Scale.Diatonic, scaleNote));
         elements.push(getNote(QuantitativeNeume.Ison));
 
-        const events = service.computePlaybackSequence(elements, options);
+        const events = service.computePlaybackSequence(elements, options, true);
 
         expect(events[0].frequency).toBeCloseTo(expectedFrequency, 2);
       },
@@ -269,7 +269,7 @@ describe('PlaybackService', () => {
         elements.push(getModeKey(4, Scale.Diatonic, ScaleNote.Pa));
         elements.push(getNote(base));
 
-        const events = service.computePlaybackSequence(elements, options);
+        const events = service.computePlaybackSequence(elements, options, true);
 
         expect(events[0].frequency).toBeCloseTo(expectedFrequency, 2);
       },
@@ -308,7 +308,7 @@ describe('PlaybackService', () => {
         elements.push(getModeKey(2, Scale.SoftChromatic, scaleNote));
         elements.push(getNote(QuantitativeNeume.Ison));
 
-        const events = service.computePlaybackSequence(elements, options);
+        const events = service.computePlaybackSequence(elements, options, true);
 
         expect(events[0].frequency).toBeCloseTo(expectedFrequency, 2);
       },
@@ -342,7 +342,7 @@ describe('PlaybackService', () => {
       elements.push(getNote(QuantitativeNeume.Oligon));
       elements.push(getNote(QuantitativeNeume.Oligon));
 
-      const events = service.computePlaybackSequence(elements, options);
+      const events = service.computePlaybackSequence(elements, options, true);
       const expectedFrequencies = [
         77.78, 87.31, 94.3, 107.9, 116.54, 130.81, 141.29, 161.67, 174.62, 196,
         211.69, 242.24, 261.63, 293.67, 317.18, 362.94, 392, 440.01,
@@ -387,7 +387,7 @@ describe('PlaybackService', () => {
         elements.push(getModeKey(2, Scale.HardChromatic, scaleNote));
         elements.push(getNote(QuantitativeNeume.Ison));
 
-        const events = service.computePlaybackSequence(elements, options);
+        const events = service.computePlaybackSequence(elements, options, true);
 
         expect(events[0].frequency).toBeCloseTo(expectedFrequency, 2);
       },
@@ -421,7 +421,7 @@ describe('PlaybackService', () => {
       elements.push(getNote(QuantitativeNeume.Oligon));
       elements.push(getNote(QuantitativeNeume.Oligon));
 
-      const events = service.computePlaybackSequence(elements, options);
+      const events = service.computePlaybackSequence(elements, options, true);
       const expectedFrequencies = [
         84.01, 87.31, 98, 103.83, 125.87, 130.81, 146.83, 155.57, 188.6, 196,
         220, 233.08, 282.57, 293.67, 329.63, 349.23, 423.38, 440.01,
@@ -464,7 +464,7 @@ describe('PlaybackService', () => {
       elements.push(getNote(QuantitativeNeume.Oligon));
       elements.push(getNote(QuantitativeNeume.Oligon));
 
-      const events = service.computePlaybackSequence(elements, options);
+      const events = service.computePlaybackSequence(elements, options, true);
       const expectedFrequencies = [
         174.62, 233.08, 220, 196, 174.62, 164.82, 146.83, 130.81, 261.63,
         293.67, 311.13,
@@ -503,7 +503,7 @@ describe('PlaybackService', () => {
       elements.push(getNote(QuantitativeNeume.Oligon));
       elements.push(getNote(QuantitativeNeume.Oligon));
 
-      const events = service.computePlaybackSequence(elements, options);
+      const events = service.computePlaybackSequence(elements, options, true);
       const expectedFrequencies = [
         174.62, 233.08, 220, 196, 174.62, 161.67, 146.83, 130.81, 261.63,
         293.67, 323.35,
@@ -542,7 +542,7 @@ describe('PlaybackService', () => {
       elements.push(getNote(QuantitativeNeume.Oligon));
       elements.push(getNote(QuantitativeNeume.Oligon));
 
-      const events = service.computePlaybackSequence(elements, options);
+      const events = service.computePlaybackSequence(elements, options, true);
       const expectedFrequencies = [
         174.62, 233.08, 220, 196, 174.62, 161.67, 146.83, 130.81, 261.63,
         293.67, 323.35,
@@ -573,7 +573,7 @@ describe('PlaybackService', () => {
       elements.push(getNote(QuantitativeNeume.Apostrophos));
       elements.push(getNote(QuantitativeNeume.Apostrophos));
 
-      const events = service.computePlaybackSequence(elements, options);
+      const events = service.computePlaybackSequence(elements, options, true);
       const expectedFrequencies = [174.62, 155.57, 146.83, 130.81, 116.54];
 
       expect(events.map((x) => x.frequency)).toBeDeepCloseTo(
@@ -597,7 +597,7 @@ describe('PlaybackService', () => {
       elements.push(getMartyria({ auto: false, note: Note.Pa }));
       elements.push(getNote(QuantitativeNeume.Ison));
 
-      const events = service.computePlaybackSequence(elements, options);
+      const events = service.computePlaybackSequence(elements, options, true);
       const expectedFrequencies = [
         getDiatonicFrequency(ScaleNote.Pa),
         getDiatonicFrequency(ScaleNote.Thi),
@@ -640,7 +640,7 @@ describe('PlaybackService', () => {
         elements.push(getNote(QuantitativeNeume.Ison));
         elements.push(getNote(QuantitativeNeume.Ison));
 
-        const events = service.computePlaybackSequence(elements, options);
+        const events = service.computePlaybackSequence(elements, options, true);
 
         expect(events.map((x) => x.transportTime)).toEqual(expectedResult);
       },


### PR DESCRIPTION
Fixes #331 by implementing support for both semantics in the playback service, with a preference that is saved per-score in the page setup screen. 