### PR TITLE
Declare a `mitt` 3.0.1 dependency

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -15,7 +15,7 @@
         "image-size": "^1.0.2",
         "jszip": "^3.10.1",
         "mime-types": "^2.1.35",
-        "mitt": "^3.0.0",
+        "mitt": "^3.0.1",
         "register-service-worker": "^1.7.2",
         "tone": "^14.8.49",
         "uuid": "^9.0.1",

--- a/package.json
+++ b/package.json
@@ -37,7 +37,7 @@
     "image-size": "^1.0.2",
     "jszip": "^3.10.1",
     "mime-types": "^2.1.35",
-    "mitt": "^3.0.0",
+    "mitt": "^3.0.1",
     "register-service-worker": "^1.7.2",
     "tone": "^14.8.49",
     "uuid": "^9.0.1",


### PR DESCRIPTION
A merely cosmetic PR; #150 updated `mitt` to 3.0.1 in `package-lock.json` but neglected to update the direct dependency declaration to the latest version.