### PR TITLE
Fix fthora calculation for enharmonic Zo

### DIFF
--- a/src/services/LayoutService.ts
+++ b/src/services/LayoutService.ts
@@ -1789,6 +1789,10 @@ export class LayoutService {
         currentShift = 0;
 
         if (modeKey.fthora) {
+          currentScale =
+            this.getScaleFromFthora(modeKey.fthora, currentNote) ||
+            currentScale;
+
           currentShift = this.getShift(
             currentNote,
             currentScale,


### PR DESCRIPTION
I noticed that the layout service was computing an incorrect martyria when the mode key had an enharmonic Zo with a fthora. This is because while the logic to process regular fthores set both `currentScale` and `currentShift`, the logic to process mode key fthores only set `currentShift`. To test this change, I tried both regular Enharmonic Grave Mode and Pentaphonic Plagal First Mode mode keys followed by an ison followed by a martyria; prior to this PR the martyria incorrectly had a diatonic root sign and after this PR it correctly had an enharmonic root sign.