### PR TITLE
Text Box Handle and Paint Format

### DIFF
--- a/electron/main/index.ts
+++ b/electron/main/index.ts
@@ -2,48 +2,49 @@
 
 import {
   app,
-  protocol,
   BrowserWindow,
-  Menu,
   dialog,
   ipcMain,
+  Menu,
   MenuItemConstructorOptions,
-  shell,
+  protocol,
   screen,
+  shell,
 } from 'electron';
-import { autoUpdater } from 'electron-updater';
 import installExtension, { VUEJS_DEVTOOLS } from 'electron-devtools-installer';
+import { autoUpdater } from 'electron-updater';
+import { promises as fs } from 'fs';
+import sizeOf from 'image-size';
+import JSZip from 'jszip';
+import mimetypes from 'mime-types';
+import path from 'path';
+import { debounce } from 'throttle-debounce';
+import { promisify } from 'util';
+
 import {
   CloseWorkspacesArgs,
   CloseWorkspacesDisposition,
-  IpcMainChannels,
-  IpcRendererChannels,
-  ShowMessageBoxArgs,
-  SaveWorkspaceArgs,
-  SaveWorkspaceAsArgs,
-  ExportWorkspaceAsPdfArgs,
-  SaveWorkspaceReplyArgs,
-  PrintWorkspaceArgs,
-  FileMenuOpenScoreArgs,
-  SaveWorkspaceAsReplyArgs,
-  FileMenuInsertTextboxArgs,
-  ExportWorkspaceAsHtmlArgs,
-  FileMenuOpenImageArgs,
   ExportPageAsImageArgs,
+  ExportWorkspaceAsHtmlArgs,
   ExportWorkspaceAsImageArgs,
   ExportWorkspaceAsImageReplyArgs,
+  ExportWorkspaceAsPdfArgs,
+  FileMenuInsertTextboxArgs,
+  FileMenuOpenImageArgs,
+  FileMenuOpenScoreArgs,
+  IpcMainChannels,
+  IpcRendererChannels,
   OpenContextMenuForTabArgs,
+  PrintWorkspaceArgs,
+  SaveWorkspaceArgs,
+  SaveWorkspaceAsArgs,
+  SaveWorkspaceAsReplyArgs,
+  SaveWorkspaceReplyArgs,
+  ShowMessageBoxArgs,
 } from '../../src/ipc/ipcChannels';
-import path from 'path';
-import { promises as fs } from 'fs';
-import { TestFileType } from '../../src/utils/TestFileType';
 import { Score } from '../../src/models/save/v1/Score';
 import { getSystemFonts } from '../../src/utils/getSystemFonts';
-import JSZip from 'jszip';
-import { debounce } from 'throttle-debounce';
-import { promisify } from 'util';
-import mimetypes from 'mime-types';
-import sizeOf from 'image-size';
+import { TestFileType } from '../../src/utils/TestFileType';
 
 // The built directory structure
 //

--- a/electron/main/index.ts
+++ b/electron/main/index.ts
@@ -1085,6 +1085,19 @@ function createMenu() {
         },
         { type: 'separator' },
         {
+          label: 'Copy &Format',
+          click() {
+            win?.webContents.send(IpcMainChannels.FileMenuCopyFormat);
+          },
+        },
+        {
+          label: 'Paste Format',
+          click() {
+            win?.webContents.send(IpcMainChannels.FileMenuPasteFormat);
+          },
+        },
+        { type: 'separator' },
+        {
           label: '&Preferences',
           accelerator: 'CmdOrCtrl+,',
           click() {

--- a/electron/main/index.ts
+++ b/electron/main/index.ts
@@ -1087,12 +1087,14 @@ function createMenu() {
         { type: 'separator' },
         {
           label: 'Copy &Format',
+          accelerator: 'CmdOrCtrl+Shift+R',
           click() {
             win?.webContents.send(IpcMainChannels.FileMenuCopyFormat);
           },
         },
         {
-          label: 'Paste Format',
+          label: 'Paste Fo&rmat',
+          accelerator: 'CmdOrCtrl+R',
           click() {
             win?.webContents.send(IpcMainChannels.FileMenuPasteFormat);
           },

--- a/src/components/Editor.vue
+++ b/src/components/Editor.vue
@@ -963,6 +963,7 @@ export default class Editor extends Vue {
   exportDialogIsOpen: boolean = false;
 
   clipboard: ScoreElement[] = [];
+  textBoxFormat: Partial<TextBoxElement> | null = null;
 
   fonts: string[] = [];
 
@@ -1691,10 +1692,15 @@ export default class Editor extends Vue {
     EventBus.$on(IpcMainChannels.FileMenuCut, this.onFileMenuCut);
     EventBus.$on(IpcMainChannels.FileMenuCopy, this.onFileMenuCopy);
     EventBus.$on(IpcMainChannels.FileMenuCopyAsHtml, this.onFileMenuCopyAsHtml);
+    EventBus.$on(IpcMainChannels.FileMenuCopyFormat, this.onFileMenuCopyFormat);
     EventBus.$on(IpcMainChannels.FileMenuPaste, this.onFileMenuPaste);
     EventBus.$on(
       IpcMainChannels.FileMenuPasteWithLyrics,
       this.onFileMenuPasteWithLyrics,
+    );
+    EventBus.$on(
+      IpcMainChannels.FileMenuPasteFormat,
+      this.onFileMenuPasteFormat,
     );
     EventBus.$on(
       IpcMainChannels.FileMenuPreferences,
@@ -1778,10 +1784,18 @@ export default class Editor extends Vue {
       IpcMainChannels.FileMenuCopyAsHtml,
       this.onFileMenuCopyAsHtml,
     );
+    EventBus.$off(
+      IpcMainChannels.FileMenuCopyFormat,
+      this.onFileMenuCopyFormat,
+    );
     EventBus.$off(IpcMainChannels.FileMenuPaste, this.onFileMenuPaste);
     EventBus.$off(
       IpcMainChannels.FileMenuPasteWithLyrics,
       this.onFileMenuPasteWithLyrics,
+    );
+    EventBus.$off(
+      IpcMainChannels.FileMenuPasteFormat,
+      this.onFileMenuPasteFormat,
     );
     EventBus.$off(
       IpcMainChannels.FileMenuPreferences,
@@ -5367,6 +5381,18 @@ export default class Editor extends Vue {
     }
   }
 
+  onFileMenuCopyFormat() {
+    if (this.selectedElement == null) {
+      return;
+    }
+
+    if (this.selectedElement.elementType === ElementType.TextBox) {
+      this.textBoxFormat = (
+        this.selectedElement as TextBoxElement
+      ).cloneFormat();
+    }
+  }
+
   onFileMenuCopyAsHtml() {
     let elements: ScoreElement[] = [];
 
@@ -5398,6 +5424,19 @@ export default class Editor extends Vue {
       this.onPasteScoreElements(true);
     } else {
       document.execCommand('paste');
+    }
+  }
+
+  onFileMenuPasteFormat() {
+    if (this.selectedElement == null || this.textBoxFormat == null) {
+      return;
+    }
+
+    if (this.selectedElement.elementType === ElementType.TextBox) {
+      this.updateTextBox(
+        this.selectedElement as TextBoxElement,
+        this.textBoxFormat,
+      );
     }
   }
 

--- a/src/components/Editor.vue
+++ b/src/components/Editor.vue
@@ -5648,6 +5648,10 @@ export default class Editor extends Vue {
   border: 1px solid goldenrod;
 }
 
+.selectedTextbox:deep(.handle) {
+  display: inline;
+}
+
 .selectedImagebox {
   border: 1px solid goldenrod;
 }

--- a/src/components/FileMenuBar.vue
+++ b/src/components/FileMenuBar.vue
@@ -31,6 +31,9 @@
       <FileMenuItem label="Paste" @click="onClickPaste" />
       <FileMenuItem label="Paste with lyrics" @click="onClickPasteWithLyrics" />
       <div class="separator" />
+      <FileMenuItem label="Copy Format" @click="onClickCopyFormat" />
+      <FileMenuItem label="Paste Format" @click="onClickPasteFormat" />
+      <div class="separator" />
       <FileMenuItem label="Preferences" @click="onClickPreferences" />
     </FileMenuBarItem>
     <FileMenuBarItem
@@ -303,6 +306,11 @@ export default class FileMenuBar extends Vue {
     this.isMenuOpen = false;
   }
 
+  onClickCopyFormat() {
+    EventBus.$emit(IpcMainChannels.FileMenuCopyFormat);
+    this.isMenuOpen = false;
+  }
+
   onClickPaste() {
     EventBus.$emit(IpcMainChannels.FileMenuPaste);
     this.isMenuOpen = false;
@@ -310,6 +318,11 @@ export default class FileMenuBar extends Vue {
 
   onClickPasteWithLyrics() {
     EventBus.$emit(IpcMainChannels.FileMenuPasteWithLyrics);
+    this.isMenuOpen = false;
+  }
+
+  onClickPasteFormat() {
+    EventBus.$emit(IpcMainChannels.FileMenuPasteFormat);
     this.isMenuOpen = false;
   }
 

--- a/src/components/TextBox.vue
+++ b/src/components/TextBox.vue
@@ -4,6 +4,7 @@
     :style="containerStyle"
     @click="$emit('select-single')"
   >
+    <span class="handle"></span>
     <ContentEditable
       ref="text"
       class="text-box"
@@ -129,5 +130,20 @@ export default class TextBox extends Vue {
 
 .text-box.underline {
   text-decoration: underline;
+}
+
+.text-box-container .handle {
+  bottom: calc(50% - 5px);
+  left: -10px;
+
+  z-index: 1;
+
+  display: none;
+}
+
+@media print {
+  .text-box-container .handle {
+    display: none !important;
+  }
 }
 </style>

--- a/src/ipc/ipcChannels.ts
+++ b/src/ipc/ipcChannels.ts
@@ -19,8 +19,10 @@ export enum IpcMainChannels {
   FileMenuCut = 'FileMenuCut',
   FileMenuCopy = 'FileMenuCopy',
   FileMenuCopyAsHtml = 'FileMenuCopyAsHtml',
+  FileMenuCopyFormat = 'FileMenuCopyFormat',
   FileMenuPaste = 'FileMenuPaste',
   FileMenuPasteWithLyrics = 'FileMenuPasteWithLyrics',
+  FileMenuPasteFormat = 'FileMenuPasteFormat',
 
   FileMenuPreferences = 'FileMenuPreferences',
 

--- a/src/models/Element.ts
+++ b/src/models/Element.ts
@@ -767,6 +767,12 @@ export class TextBoxElement extends ScoreElement {
       useDefaultStyle: this.useDefaultStyle,
     } as Partial<TextBoxElement>;
   }
+
+  public cloneFormat() {
+    const format = this.getClipboardProperties();
+    delete format.content;
+    return format;
+  }
 }
 
 export class ModeKeyElement extends ScoreElement {


### PR DESCRIPTION
This PR adds a handle to the left side of text boxes. This handle can be clicked to select the textbox without selecting the text, which makes copy/paste of the element easier. 

This PR also adds `Copy Format` and `Paste Format` menu items to the edit menu that make it easy to transfer the format of one text box to another.

Fixes #258 