### PR TITLE
Use alt rendering for ImageBox when printing

### DIFF
--- a/src/components/Editor.vue
+++ b/src/components/Editor.vue
@@ -353,6 +353,7 @@
                       :ref="`element-${getElementIndex(element)}`"
                       :element="element"
                       :zoom="zoom"
+                      :printMode="printMode"
                       :class="[{ selectedImagebox: isSelected(element) }]"
                       @select-single="selectedElement = element"
                       @update:size="

--- a/src/components/ImageBox.vue
+++ b/src/components/ImageBox.vue
@@ -4,7 +4,15 @@
     :style="containerStyle"
     @click="$emit('select-single')"
   >
+    <img
+      v-if="printMode"
+      class="image-box"
+      :src="element.data"
+      :style="imageStyle"
+    />
+
     <vue-draggable-resizable
+      v-else
       :lock-aspect-ratio="element.lockAspectRatio"
       :w="imageWidthZoomed"
       :h="imageHeightZoomed"
@@ -36,6 +44,7 @@ import { withZoom } from '@/utils/withZoom';
 export default class ImageBox extends Vue {
   @Prop() element!: ImageBoxElement;
   @Prop() zoom!: number;
+  @Prop() printMode!: boolean;
 
   get imageWidthZoomed() {
     return this.element.imageWidth * this.zoom;


### PR DESCRIPTION
Fixes #466.

When zoom is not 100%, the `vue-draggable-resize` wrapper element is not set to the correct size when printing. To fix this, the image is now displayed without a wrapper when `printMode` is activated.