### PR TITLE
Use system font

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -172,7 +172,8 @@ body {
 
   font-size: 16px;
 
-  font-family: sans-serif;
+  font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', 'Noto Sans',
+    Helvetica, Arial, sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji';
 }
 
 .ok-btn {


### PR DESCRIPTION
See [this page](https://css-tricks.com/snippets/css/system-font-stack/). When running on macOS Monterey I noticed the fonts were in Helvetica instead of the expected San Francisco Pro like all other applications. This fixes the problem. The implementation was stolen from GitHub.com's stylesheets.