### PR TITLE
Use system font in more places

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -171,7 +171,13 @@ body {
   overflow: hidden;
 
   font-size: 16px;
+}
 
+body,
+button,
+input,
+select,
+textarea {
   font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', 'Noto Sans',
     Helvetica, Arial, sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji';
 }


### PR DESCRIPTION
Amends #471. After using the application more, I found there were still some spots that didn't use the system font: those where a `button` or similar element was using the browser's default stylesheet, which override the font with `sans-serif`. After applying this patch I scoured the UI a bit further and didn't see any remaining use of Arial. Note that the `*` selector is too broad and results in some ugly red boxes being drawn, so I avoided that approach.